### PR TITLE
Add skills system, theme support, GPU status, and extensibility improvements

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OctoAlly</title>
+    <script src="/assets/clipboard-bridge.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -29,6 +29,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
+        "fuse.js": "^7.3.0",
         "lucide-react": "^0.575.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -3370,6 +3371,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/gensync": {

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@octoally/dashboard",
-  "version": "1.0.59",
+  "version": "1.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@octoally/dashboard",
-      "version": "1.0.59",
+      "version": "1.0.56",
       "license": "Apache-2.0 WITH Commons-Clause",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
@@ -2371,9 +2371,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2674,9 +2674,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5063,9 +5063,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -33,6 +33,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "fuse.js": "^7.3.0",
     "lucide-react": "^0.575.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/dashboard/public/assets/clipboard-bridge.js
+++ b/dashboard/public/assets/clipboard-bridge.js
@@ -1,0 +1,386 @@
+/**
+ * Clipboard Bridge for OctoAlly
+ *
+ * Fixes two problems:
+ * 1. Ctrl+V doesn't paste text (OctoAlly uses Ctrl+Shift+V, but Windows users expect Ctrl+V)
+ * 2. No way to paste images — uploads image, copies path to clipboard
+ *
+ * Also supports drag-and-drop for images.
+ */
+(function () {
+  'use strict';
+
+  // --- Config ---
+  // Standalone image-drop server on port 7799 (same host, Tailscale-accessible)
+  var IMAGE_DROP_PORT = 7799;
+  var UPLOAD_URL = 'http://' + window.location.hostname + ':' + IMAGE_DROP_PORT + '/upload';
+  var DEBUG_URL = '/api/debug/log'; // kept for optional OctoAlly debug logging
+  var DEBOUNCE_MS = 500;
+  var MAX_SIZE_BYTES = 10 * 1024 * 1024;
+  var IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/bmp', 'image/tiff'];
+
+  var lastActionTime = 0;
+  var _ctrlVPending = false;
+  var _ctrlVFallbackTimer = null;
+
+  // --- Remote debug logger ---
+  var _logBuffer = [];
+  var _logTimer = null;
+
+  function rlog() {
+    // Debug logging disabled — re-enable by uncommenting body:
+    // var line = '[cb] ' + arguments[0];
+    // console.log(line);
+    // _logBuffer.push(line);
+    // clearTimeout(_logTimer);
+    // _logTimer = setTimeout(flushLogs, 300);
+  }
+
+  function flushLogs() {
+    if (_logBuffer.length === 0) return;
+    var msgs = _logBuffer.splice(0);
+    try {
+      fetch(DEBUG_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ msgs: msgs })
+      }).catch(function () {});
+    } catch (e) {}
+  }
+
+  rlog('script loading...');
+
+  // --- WebSocket capture ---
+  var _WS = window.WebSocket;
+  var _termSockets = [];
+
+  window.WebSocket = function (url, protocols) {
+    var ws = protocols !== undefined ? new _WS(url, protocols) : new _WS(url);
+
+    if (typeof url === 'string' && url.indexOf('/api/terminal/') !== -1 && url.indexOf('passive=1') === -1) {
+      _termSockets.push(ws);
+      // rlog('terminal WS captured: ' + url);
+      ws.addEventListener('close', function () {
+        var i = _termSockets.indexOf(ws);
+        if (i !== -1) _termSockets.splice(i, 1);
+        // rlog('terminal WS closed, remaining: ' + _termSockets.length);
+      });
+    }
+
+    return ws;
+  };
+
+  window.WebSocket.prototype = _WS.prototype;
+  window.WebSocket.CONNECTING = _WS.CONNECTING;
+  window.WebSocket.OPEN = _WS.OPEN;
+  window.WebSocket.CLOSING = _WS.CLOSING;
+  window.WebSocket.CLOSED = _WS.CLOSED;
+
+  function sendTextToTerminal(text) {
+    for (var i = _termSockets.length - 1; i >= 0; i--) {
+      var ws = _termSockets[i];
+      if (ws.readyState === _WS.OPEN) {
+        ws.send(JSON.stringify({ type: 'input', data: text, paste: true }));
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // --- DOM helpers ---
+
+  function isTerminalFocused() {
+    var el = document.activeElement;
+    if (!el) return false;
+    // Check multiple ways — xterm versions differ
+    if (el.classList && el.classList.contains('xterm-helper-textarea')) return true;
+    // Check if inside an xterm container
+    var parent = el.closest ? el.closest('.xterm') : null;
+    if (parent) return true;
+    // Check textarea inside xterm
+    if (el.tagName === 'TEXTAREA' && el.parentElement && el.parentElement.classList &&
+        el.parentElement.classList.contains('xterm-helper-textarea-container')) return true;
+    return false;
+  }
+
+  function isNativeInputFocused() {
+    var el = document.activeElement;
+    if (!el) return false;
+    if ((el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') && !isTerminalFocused()) {
+      return true;
+    }
+    return el.isContentEditable === true;
+  }
+
+  // --- Toast ---
+
+  var toastEl = null;
+  var toastTimer = null;
+
+  function showToast(msg, isError) {
+    if (!toastEl) {
+      toastEl = document.createElement('div');
+      toastEl.style.cssText =
+        'position:fixed;bottom:20px;right:20px;z-index:99999;padding:12px 18px;' +
+        'border-radius:8px;font-family:monospace;font-size:13px;line-height:1.4;' +
+        'max-width:440px;opacity:0;transform:translateY(8px);' +
+        'transition:opacity .2s,transform .2s;pointer-events:none;color:#e0e0e0;' +
+        'background:rgba(30,30,30,.95);border:1px solid #444;' +
+        'box-shadow:0 4px 12px rgba(0,0,0,.4)';
+      document.body.appendChild(toastEl);
+    }
+    toastEl.textContent = msg;
+    toastEl.style.borderColor = isError ? '#c44' : '#4a4';
+    toastEl.style.opacity = '1';
+    toastEl.style.transform = 'translateY(0)';
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(function () {
+      if (toastEl) {
+        toastEl.style.opacity = '0';
+        toastEl.style.transform = 'translateY(8px)';
+      }
+    }, isError ? 5000 : 3500);
+  }
+
+  // --- Clipboard write ---
+
+  function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text).then(function () { return true; }, function () { return fallbackCopy(text); });
+    }
+    return Promise.resolve(fallbackCopy(text));
+  }
+
+  function fallbackCopy(text) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.cssText = 'position:fixed;left:-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    var ok = false;
+    try { ok = document.execCommand('copy'); } catch (e) {}
+    ta.remove();
+    return ok;
+  }
+
+  // --- Image upload ---
+
+  function uploadImage(file) {
+    if (file.size > MAX_SIZE_BYTES) {
+      showToast('Image too large (max 10MB)', true);
+      return Promise.resolve(null);
+    }
+
+    // rlog('uploading image: ' + file.name + ' size=' + file.size + ' type=' + file.type);
+
+    return new Promise(function (resolve, reject) {
+      var reader = new FileReader();
+      reader.onload = function () { resolve(reader.result); };
+      reader.onerror = function () { reject(reader.error); };
+      reader.readAsDataURL(file);
+    }).then(function (base64) {
+      // rlog('base64 ready, length=' + base64.length);
+      var name = file.name || ('paste.' + (file.type.split('/')[1] || 'png'));
+      return fetch(UPLOAD_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name, data: base64 })
+      });
+    }).then(function (resp) {
+      // rlog('upload response: ' + resp.status);
+      if (!resp.ok) {
+        showToast('Upload failed (' + resp.status + ')', true);
+        return null;
+      }
+      return resp.json().then(function (j) { return j.path; });
+    });
+  }
+
+  function isImageType(type) {
+    return IMAGE_TYPES.indexOf(type) !== -1;
+  }
+
+  function getImageFromDataTransfer(dt) {
+    if (!dt) return null;
+    if (dt.files) {
+      for (var i = 0; i < dt.files.length; i++) {
+        if (isImageType(dt.files[i].type)) return dt.files[i];
+      }
+    }
+    if (dt.items) {
+      for (var j = 0; j < dt.items.length; j++) {
+        if (dt.items[j].kind === 'file' && isImageType(dt.items[j].type)) {
+          return dt.items[j].getAsFile();
+        }
+      }
+    }
+    return null;
+  }
+
+  function handleImageUpload(file) {
+    showToast('Uploading image...', false);
+    uploadImage(file).then(function (path) {
+      if (!path) return;
+      // rlog('image saved: ' + path);
+      copyToClipboard(path).then(function (copied) {
+        if (copied) {
+          showToast('Path copied! Ctrl+V to paste: ' + path, false);
+        } else {
+          showToast('Saved: ' + path + ' (copy manually)', true);
+        }
+      });
+    }).catch(function (err) {
+      // rlog('upload error: ' + (err.message || err));
+      showToast('Upload failed: ' + (err.message || err), true);
+    });
+  }
+
+  // --- Clipboard API fallback ---
+
+  function clipboardApiFallback() {
+    // rlog('using clipboard API fallback');
+    if (navigator.clipboard && navigator.clipboard.read) {
+      navigator.clipboard.read().then(function (items) {
+        // rlog('clipboard.read() got ' + items.length + ' items');
+        for (var i = 0; i < items.length; i++) {
+          var types = items[i].types;
+          // rlog('  item ' + i + ' types: ' + types.join(','));
+          for (var t = 0; t < types.length; t++) {
+            if (isImageType(types[t])) {
+              items[i].getBlob(types[t]).then(function (blob) {
+                var ext = blob.type.split('/')[1] || 'png';
+                handleImageUpload(new File([blob], 'paste.' + ext, { type: blob.type }));
+              });
+              return;
+            }
+          }
+          if (types.indexOf('text/plain') !== -1) {
+            items[i].getBlob('text/plain').then(function (blob) {
+              return blob.text();
+            }).then(function (text) {
+              if (text && !sendTextToTerminal(text)) {
+                showToast('No active terminal for paste', true);
+              }
+            });
+            return;
+          }
+        }
+      }).catch(function (err) {
+        // rlog('clipboard.read() denied: ' + (err.message || err));
+        if (navigator.clipboard && navigator.clipboard.readText) {
+          navigator.clipboard.readText().then(function (text) {
+            if (text && !sendTextToTerminal(text)) {
+              showToast('No active terminal for paste', true);
+            }
+          }).catch(function (err2) {
+            // rlog('readText() also denied: ' + (err2.message || err2));
+            showToast('Clipboard access denied — try Ctrl+Shift+V', true);
+          });
+        }
+      });
+    }
+  }
+
+  // --- Keydown: ALL key events logged for diagnosis ---
+
+  document.addEventListener('keydown', function (e) {
+    // Log every Ctrl+V attempt regardless of focus
+    if (e.ctrlKey && (e.key === 'v' || e.key === 'V')) {
+      var el = document.activeElement;
+      var elInfo = el ? (el.tagName + '.' + (el.className || '').substring(0, 60)) : 'null';
+      // rlog('Ctrl+V detected | shift=' + e.shiftKey + ' | activeElement=' + elInfo +
+      //   ' | isTerminal=' + isTerminalFocused() + ' | isNative=' + isNativeInputFocused() +
+      //   ' | sockets=' + _termSockets.length);
+    }
+
+    // Only Ctrl+V without Shift
+    if (!(e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && (e.key === 'v' || e.key === 'V'))) return;
+    if (isNativeInputFocused()) return;
+    if (!isTerminalFocused()) return;
+
+    var now = Date.now();
+    if (now - lastActionTime < DEBOUNCE_MS) {
+      e.preventDefault();
+      return;
+    }
+    // Don't set lastActionTime here — let the paste handler set it.
+    // Setting it here causes the paste handler's debounce to reject the event.
+
+    e.stopPropagation();
+    _ctrlVPending = true;
+    // rlog('keydown intercepted, waiting for paste event...');
+
+    clearTimeout(_ctrlVFallbackTimer);
+    _ctrlVFallbackTimer = setTimeout(function () {
+      if (_ctrlVPending) {
+        _ctrlVPending = false;
+        // rlog('paste event never fired (200ms timeout), using clipboard API fallback');
+        clipboardApiFallback();
+      }
+    }, 200);
+  }, true);
+
+  // --- Paste event (primary handler) ---
+
+  document.addEventListener('paste', function (e) {
+    var isFromCtrlV = _ctrlVPending;
+    if (isFromCtrlV) {
+      _ctrlVPending = false;
+      clearTimeout(_ctrlVFallbackTimer);
+    }
+
+    var types = e.clipboardData ? Array.from(e.clipboardData.types) : [];
+    var fileCount = e.clipboardData ? e.clipboardData.files.length : 0;
+    // rlog('paste event | fromCtrlV=' + isFromCtrlV + ' | types=' + types.join(',') + ' | files=' + fileCount);
+
+    var file = getImageFromDataTransfer(e.clipboardData);
+    if (file) {
+      // rlog('image found in paste: ' + file.type + ' size=' + file.size);
+      var now = Date.now();
+      if (now - lastActionTime < DEBOUNCE_MS) return;
+      lastActionTime = now;
+      e.preventDefault();
+      e.stopPropagation();
+      handleImageUpload(file);
+      return;
+    }
+
+    if (isFromCtrlV) {
+      var text = '';
+      try { text = (e.clipboardData || window.clipboardData).getData('text/plain'); } catch (ex) {}
+      // rlog('text from paste event: ' + (text ? text.length + ' chars' : 'empty'));
+      if (text) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!sendTextToTerminal(text)) {
+          showToast('No active terminal for paste', true);
+        }
+        return;
+      }
+    }
+  }, true);
+
+  // --- Drag and drop ---
+
+  document.addEventListener('dragover', function (e) {
+    if (e.dataTransfer && e.dataTransfer.types && e.dataTransfer.types.indexOf('Files') !== -1) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    }
+  });
+
+  document.addEventListener('drop', function (e) {
+    var file = getImageFromDataTransfer(e.dataTransfer);
+    if (!file) return;
+
+    e.preventDefault();
+    var now = Date.now();
+    if (now - lastActionTime < DEBOUNCE_MS) return;
+    lastActionTime = now;
+
+    // rlog('image dropped: ' + file.type + ' size=' + file.size);
+    handleImageUpload(file);
+  });
+
+  rlog('script loaded OK, WS patched');
+})();

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -11,6 +11,7 @@ import { isDesktop, isElectron, getDesktopVersion } from './lib/tauri';
 import { AgentGuideButton } from './components/AgentGuide';
 import { CloseTabModal } from './components/CloseTabModal';
 import { CloseAppModal } from './components/CloseAppModal';
+import { ThemeToggle, useTheme } from './components/ThemeToggle';
 import { SettingsModal } from './components/SettingsModal';
 import { ActiveTerminals } from './components/ActiveTerminals';
 import { GlobalMicButton } from './components/GlobalMicButton';
@@ -224,6 +225,7 @@ function Dashboard() {
     });
     return () => unlisten?.();
   }, []);
+  const { theme, setTheme } = useTheme();
 
   const dismissActiveTerminals = useCallback(() => {
     setShowActiveTerminals(false);
@@ -497,6 +499,7 @@ function Dashboard() {
               )}
             </div>
           )}
+          <ThemeToggle theme={theme} setTheme={setTheme} />
           <button
             onClick={() => setShowSettings(true)}
             className="p-1.5 rounded-md transition-colors hover:opacity-80"

--- a/dashboard/src/components/ActiveEvents.tsx
+++ b/dashboard/src/components/ActiveEvents.tsx
@@ -3,6 +3,7 @@ import { useStreamStore } from '../lib/websocket';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { Radio, Terminal, FileEdit, Zap, AlertCircle, ArrowLeft, FolderOpen } from 'lucide-react';
+import { ModelBadge, parseRouteDecision } from './ModelBadge';
 
 function stripAnsiCodes(text: string): string {
   // eslint-disable-next-line no-control-regex
@@ -24,6 +25,7 @@ const typeIcons: Record<string, typeof Radio> = {
   session_start: Radio,
   session_end: Radio,
   pty_output: Terminal,
+  route_decision: Radio,
 };
 
 const typeColors: Record<string, string> = {
@@ -34,6 +36,7 @@ const typeColors: Record<string, string> = {
   session_start: '#facc15',
   session_end: '#94a3b8',
   pty_output: '#34d399',
+  route_decision: '#94a3b8',
 };
 
 interface ActiveEventsProps {
@@ -149,6 +152,8 @@ export function ActiveEvents({ onBack, onGoToSession }: ActiveEventsProps) {
                 else if (cmd) summary = cleanOutput(cmd).slice(0, 80);
               }
 
+              const routeDecision = parseRouteDecision(event.type, event.data);
+
               return (
                 <div
                   key={event.id}
@@ -168,6 +173,9 @@ export function ActiveEvents({ onBack, onGoToSession }: ActiveEventsProps) {
                         <span className="text-xs font-medium" style={{ color: 'var(--text-primary)' }}>
                           {event.tool_name}
                         </span>
+                      )}
+                      {routeDecision && (
+                        <ModelBadge data={routeDecision} />
                       )}
                       {session && (
                         <button

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { Search } from 'lucide-react';
+import type { SkillItem } from '../types/skills';
+
+interface CommandPaletteProps {
+  projectPath: string;
+}
+
+export function CommandPalette({ projectPath }: CommandPaletteProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [skills, setSkills] = useState<SkillItem[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Global Ctrl+K listener
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        setOpen(prev => !prev);
+        setQuery('');
+        setSelectedIndex(0);
+      }
+      if (e.key === 'Escape' && open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open]);
+
+  const [loaded, setLoaded] = useState(false);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 50);
+      // Fetch skills if not loaded yet
+      if (!loaded) {
+        fetch(`/api/skills?project_path=${encodeURIComponent(projectPath)}`)
+          .then(r => r.json())
+          .then(data => {
+            setSkills(data.skills || []);
+            setLoaded(true);
+          })
+          .catch(() => {});
+      }
+    }
+  }, [open, projectPath, loaded]);
+
+  // Reset loaded state when project changes
+  useEffect(() => { setLoaded(false); }, [projectPath]);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return skills.slice(0, 20);
+    const q = query.toLowerCase();
+    return skills
+      .filter(s => s.id.toLowerCase().includes(q) || s.category.toLowerCase().includes(q) || s.description?.toLowerCase().includes(q))
+      .sort((a, b) => {
+        const aPrefix = a.id.toLowerCase().startsWith(q) ? 100 : 0;
+        const bPrefix = b.id.toLowerCase().startsWith(q) ? 100 : 0;
+        return bPrefix - aPrefix;
+      })
+      .slice(0, 30);
+  }, [skills, query]);
+
+  // Reset selection on filter change
+  useEffect(() => setSelectedIndex(0), [filtered]);
+
+  const invoke = useCallback((skill: SkillItem) => {
+    window.dispatchEvent(new CustomEvent('octoally:skill-invoke', {
+      detail: { command: skill.command },
+    }));
+    setOpen(false);
+  }, []);
+
+  const paletteRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex(prev => Math.min(prev + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex(prev => Math.max(prev - 1, 0));
+    } else if (e.key === 'Enter' && filtered[selectedIndex]) {
+      e.preventDefault();
+      invoke(filtered[selectedIndex]);
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      const focusable = paletteRef.current?.querySelectorAll<HTMLElement>(
+        'input, button:not([disabled])'
+      );
+      if (focusable && focusable.length > 0) {
+        const currentIdx = Array.from(focusable).indexOf(
+          document.activeElement as HTMLElement
+        );
+        const nextIdx = e.shiftKey
+          ? (currentIdx - 1 + focusable.length) % focusable.length
+          : (currentIdx + 1) % focusable.length;
+        focusable[nextIdx].focus();
+      }
+    }
+  }, [filtered, selectedIndex, invoke]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-label="Command palette"
+      className="fixed inset-0 z-[9999] flex items-start justify-center pt-[15vh]"
+      onClick={() => setOpen(false)}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.5)' }} />
+
+      {/* Palette */}
+      <div
+        ref={paletteRef}
+        className="relative w-full max-w-lg rounded-xl shadow-2xl overflow-hidden"
+        style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
+        onClick={e => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-2 px-4 py-3" style={{ borderBottom: '1px solid var(--border)' }}>
+          <Search className="w-4 h-4 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search skills..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            aria-label="Search skills"
+            className="flex-1 text-sm bg-transparent outline-none"
+            style={{ color: 'var(--text-primary)' }}
+          />
+          <kbd
+            className="text-[10px] px-1.5 py-0.5 rounded"
+            style={{ background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', border: '1px solid var(--border)' }}
+          >
+            Esc
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <div role="listbox" className="max-h-[320px] overflow-y-auto py-1">
+          {filtered.length === 0 ? (
+            <div className="px-4 py-6 text-center text-sm" style={{ color: 'var(--text-tertiary)' }}>
+              No skills found
+            </div>
+          ) : (
+            filtered.map((skill, i) => (
+              <button
+                key={skill.id}
+                role="option"
+                aria-selected={i === selectedIndex}
+                onClick={() => invoke(skill)}
+                className="w-full flex items-center gap-3 px-4 py-2 text-left transition-colors"
+                style={{
+                  background: i === selectedIndex ? 'var(--bg-tertiary)' : 'transparent',
+                }}
+                onMouseEnter={() => setSelectedIndex(i)}
+              >
+                <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                  {skill.command}
+                </span>
+                <span className="text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
+                  {skill.category}
+                </span>
+                {skill.description && (
+                  <span className="text-[11px] ml-auto truncate max-w-[200px]" style={{ color: 'var(--text-tertiary)' }}>
+                    {skill.description}
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          className="flex items-center gap-4 px-4 py-2 text-[10px]"
+          style={{ borderTop: '1px solid var(--border)', color: 'var(--text-tertiary)' }}
+        >
+          <span><kbd className="font-mono">Enter</kbd> to run</span>
+          <span><kbd className="font-mono">&uarr;&darr;</kbd> to navigate</span>
+          <span><kbd className="font-mono">Esc</kbd> to close</span>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/dashboard/src/components/EventStream.tsx
+++ b/dashboard/src/components/EventStream.tsx
@@ -3,6 +3,7 @@ import { useStreamStore } from '../lib/websocket';
 import { api } from '../lib/api';
 import type { Event } from '../lib/api';
 import { Radio, Terminal, FileEdit, Zap, AlertCircle } from 'lucide-react';
+import { ModelBadge, parseRouteDecision } from './ModelBadge';
 
 function stripAnsiCodes(text: string): string {
   // eslint-disable-next-line no-control-regex
@@ -27,6 +28,7 @@ const typeIcons: Record<string, typeof Radio> = {
   session_resume: Radio,
   session_adopt: Radio,
   pty_output: Terminal,
+  route_decision: Radio,
 };
 
 const typeColors: Record<string, string> = {
@@ -40,6 +42,7 @@ const typeColors: Record<string, string> = {
   session_resume: '#22d3ee',
   session_adopt: '#c084fc',
   pty_output: '#34d399',
+  route_decision: '#94a3b8',
 };
 
 interface EventStreamProps {
@@ -153,6 +156,8 @@ export function EventStream({ sessionId, sessionIds }: EventStreamProps = {}) {
                 else if (task) summary = task;
               }
 
+              const routeDecision = parseRouteDecision(event.type, event.data);
+
               return (
                 <div
                   key={event.id}
@@ -161,7 +166,7 @@ export function EventStream({ sessionId, sessionIds }: EventStreamProps = {}) {
                 >
                   <Icon className="w-4 h-4 mt-0.5 shrink-0" style={{ color }} />
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
                       <span
                         className="text-[10px] px-1.5 py-0.5 rounded font-medium"
                         style={{ background: `${color}15`, color }}
@@ -172,6 +177,9 @@ export function EventStream({ sessionId, sessionIds }: EventStreamProps = {}) {
                         <span className="text-xs font-medium" style={{ color: 'var(--text-primary)' }}>
                           {event.tool_name}
                         </span>
+                      )}
+                      {routeDecision && (
+                        <ModelBadge data={routeDecision} />
                       )}
                       <span className="text-[10px] ml-auto shrink-0" style={{ color: 'var(--text-secondary)' }}>
                         {new Date(event.timestamp).toLocaleTimeString()}

--- a/dashboard/src/components/Keybindings.tsx
+++ b/dashboard/src/components/Keybindings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 export interface Keybinding {
   id: string;

--- a/dashboard/src/components/Keybindings.tsx
+++ b/dashboard/src/components/Keybindings.tsx
@@ -1,0 +1,165 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+export interface Keybinding {
+  id: string;
+  label: string;
+  keys: string;  // e.g., "Ctrl+S", "Ctrl+Shift+P"
+  action: string;
+  category: string;
+  enabled: boolean;
+}
+
+const DEFAULT_KEYBINDINGS: Keybinding[] = [
+  { id: 'kb-new-session', label: 'New Session', keys: 'Ctrl+N', action: 'new_session', category: 'session', enabled: true },
+  { id: 'kb-close-session', label: 'Close Session', keys: 'Ctrl+W', action: 'close_session', category: 'session', enabled: true },
+  { id: 'kb-command-palette', label: 'Command Palette', keys: 'Ctrl+Shift+P', action: 'command_palette', category: 'navigation', enabled: true },
+  { id: 'kb-toggle-sidebar', label: 'Toggle Sidebar', keys: 'Ctrl+B', action: 'toggle_sidebar', category: 'ui', enabled: true },
+  { id: 'kb-focus-input', label: 'Focus Input', keys: 'Ctrl+L', action: 'focus_input', category: 'navigation', enabled: true },
+];
+
+interface KeybindingsProps {
+  onAction?: (action: string) => void;
+  customBindings?: Keybinding[];
+}
+
+function parseKeys(keys: string): { ctrl: boolean; shift: boolean; alt: boolean; key: string } {
+  const parts = keys.split('+').map(p => p.trim().toLowerCase());
+  return {
+    ctrl: parts.includes('ctrl') || parts.includes('cmd'),
+    shift: parts.includes('shift'),
+    alt: parts.includes('alt'),
+    key: parts.filter(p => !['ctrl', 'cmd', 'shift', 'alt'].includes(p))[0] || '',
+  };
+}
+
+function matchesEvent(binding: Keybinding, e: KeyboardEvent): boolean {
+  const parsed = parseKeys(binding.keys);
+  return (
+    binding.enabled &&
+    e.ctrlKey === parsed.ctrl &&
+    e.shiftKey === parsed.shift &&
+    e.altKey === parsed.alt &&
+    e.key.toLowerCase() === parsed.key
+  );
+}
+
+function detectConflicts(bindings: Keybinding[]): Map<string, string[]> {
+  const conflicts = new Map<string, string[]>();
+  const keyMap = new Map<string, string[]>();
+
+  for (const b of bindings) {
+    if (!b.enabled) continue;
+    const normalized = b.keys.toLowerCase().split('+').sort().join('+');
+    const existing = keyMap.get(normalized) || [];
+    existing.push(b.label);
+    keyMap.set(normalized, existing);
+  }
+
+  for (const [keys, labels] of keyMap) {
+    if (labels.length > 1) {
+      conflicts.set(keys, labels);
+    }
+  }
+
+  return conflicts;
+}
+
+export default function Keybindings({ onAction, customBindings }: KeybindingsProps) {
+  const [bindings, setBindings] = useState<Keybinding[]>(customBindings || DEFAULT_KEYBINDINGS);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [conflicts, setConflicts] = useState<Map<string, string[]>>(new Map());
+
+  useEffect(() => {
+    setConflicts(detectConflicts(bindings));
+  }, [bindings]);
+
+  // Global keydown listener
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      for (const binding of bindings) {
+        if (matchesEvent(binding, e)) {
+          e.preventDefault();
+          onAction?.(binding.action);
+          return;
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [bindings, onAction]);
+
+  const toggleBinding = useCallback((id: string) => {
+    setBindings(prev => prev.map(b =>
+      b.id === id ? { ...b, enabled: !b.enabled } : b
+    ));
+  }, []);
+
+  const updateKeys = useCallback((id: string, newKeys: string) => {
+    setBindings(prev => prev.map(b =>
+      b.id === id ? { ...b, keys: newKeys } : b
+    ));
+    setEditing(null);
+  }, []);
+
+  const categories = [...new Set(bindings.map(b => b.category))];
+
+  return (
+    <div style={{ padding: 16, fontFamily: 'monospace', color: '#ddd' }}>
+      <h3 style={{ margin: '0 0 12px' }}>Keyboard Shortcuts</h3>
+
+      {conflicts.size > 0 && (
+        <div style={{ background: '#442200', padding: 8, borderRadius: 4, marginBottom: 12, fontSize: 12 }}>
+          Conflicts detected: {[...conflicts.entries()].map(([k, labels]) =>
+            `${k} (${labels.join(', ')})`
+          ).join('; ')}
+        </div>
+      )}
+
+      {categories.map(cat => (
+        <div key={cat} style={{ marginBottom: 16 }}>
+          <h4 style={{ color: '#888', textTransform: 'uppercase', fontSize: 11, margin: '0 0 8px' }}>{cat}</h4>
+          {bindings.filter(b => b.category === cat).map(binding => (
+            <div
+              key={binding.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '4px 8px',
+                borderBottom: '1px solid #333',
+                opacity: binding.enabled ? 1 : 0.5,
+              }}
+            >
+              <span style={{ flex: 1 }}>{binding.label}</span>
+              {editing === binding.id ? (
+                <input
+                  autoFocus
+                  style={{ width: 120, background: '#333', color: '#fff', border: '1px solid #555', padding: '2px 6px' }}
+                  defaultValue={binding.keys}
+                  onBlur={e => updateKeys(binding.id, e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter') updateKeys(binding.id, (e.target as HTMLInputElement).value); }}
+                />
+              ) : (
+                <code
+                  onClick={() => setEditing(binding.id)}
+                  style={{ cursor: 'pointer', background: '#333', padding: '2px 8px', borderRadius: 3, fontSize: 12 }}
+                >
+                  {binding.keys}
+                </code>
+              )}
+              <button
+                onClick={() => toggleBinding(binding.id)}
+                style={{ marginLeft: 8, cursor: 'pointer', background: 'none', border: 'none', color: binding.enabled ? '#4CAF50' : '#666', fontSize: 14 }}
+              >
+                {binding.enabled ? 'ON' : 'OFF'}
+              </button>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export { DEFAULT_KEYBINDINGS, detectConflicts, parseKeys };

--- a/dashboard/src/components/ModelBadge.tsx
+++ b/dashboard/src/components/ModelBadge.tsx
@@ -1,0 +1,122 @@
+/**
+ * ModelBadge — small color-coded pill showing which backend handled a routing decision.
+ *
+ * Parses a route_decision event's data payload and renders:
+ *   [RouteLabel] [confidence%]
+ *
+ * Color mapping:
+ *   claude / claude_code_plan  → blue  (#60a5fa)
+ *   gemini / gemini_*          → yellow (#facc15)
+ *   deepthink / *deep*         → purple (#c084fc)
+ *   haiku                      → green  (#34d399)
+ *   default                    → slate  (#94a3b8)
+ */
+
+export interface RouteDecisionData {
+  route?: string;
+  provider_backend?: string;
+  capability_lane?: string;
+  execution_mode?: string;
+  availability_status?: string;
+  confidence?: number;
+}
+
+interface ModelBadgeColors {
+  bg: string;
+  text: string;
+  dot: string;
+}
+
+function resolveColors(route: string): ModelBadgeColors {
+  const r = route.toLowerCase();
+  if (r.includes('deepthink') || r.includes('deep')) {
+    return { bg: '#c084fc18', text: '#c084fc', dot: '#c084fc' };
+  }
+  if (r.includes('gemini')) {
+    return { bg: '#facc1518', text: '#facc15', dot: '#facc15' };
+  }
+  if (r.includes('haiku')) {
+    return { bg: '#34d39918', text: '#34d399', dot: '#34d399' };
+  }
+  if (r.includes('claude')) {
+    return { bg: '#60a5fa18', text: '#60a5fa', dot: '#60a5fa' };
+  }
+  // fallback
+  return { bg: '#94a3b818', text: '#94a3b8', dot: '#94a3b8' };
+}
+
+function formatLabel(route: string, backend?: string): string {
+  // Prefer the backend label when it adds specificity
+  const src = backend || route;
+  // Strip snake_case underscores for display, title-case first word
+  const parts = src.split('_');
+  const first = parts[0];
+  const display = first.charAt(0).toUpperCase() + first.slice(1);
+  // Append the second part only if it meaningfully differs (e.g. "claude_code_plan" → "Claude Code")
+  if (parts[1] && parts[1] !== 'code' && parts[1] !== parts[0]) {
+    return `${display} ${parts[1].charAt(0).toUpperCase() + parts[1].slice(1)}`;
+  }
+  if (parts[1] === 'code') {
+    return `${display} Code`;
+  }
+  return display;
+}
+
+interface ModelBadgeProps {
+  data: RouteDecisionData;
+  /** Show the confidence percentage next to the label. Default: true */
+  showConfidence?: boolean;
+}
+
+export function ModelBadge({ data, showConfidence = true }: ModelBadgeProps) {
+  const route = data.route || data.provider_backend || 'unknown';
+  const { bg, text, dot } = resolveColors(route);
+  const label = formatLabel(route, data.provider_backend);
+  const pct = data.confidence != null ? Math.round(data.confidence * 100) : null;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0"
+      style={{ background: bg, color: text }}
+      title={[
+        `Route: ${route}`,
+        data.provider_backend ? `Backend: ${data.provider_backend}` : '',
+        data.execution_mode ? `Mode: ${data.execution_mode}` : '',
+        data.availability_status ? `Status: ${data.availability_status}` : '',
+        pct != null ? `Confidence: ${pct}%` : '',
+      ].filter(Boolean).join('\n')}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full shrink-0"
+        style={{ background: dot }}
+      />
+      {label}
+      {showConfidence && pct != null && (
+        <span style={{ opacity: 0.75 }}>{pct}%</span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Parse the raw JSON string stored in event.data and return routing fields,
+ * or null if the event is not a route_decision or has no routing info.
+ */
+export function parseRouteDecision(eventType: string, rawData: string | null): RouteDecisionData | null {
+  if (eventType !== 'route_decision') return null;
+  if (!rawData) return null;
+  try {
+    const parsed = JSON.parse(rawData) as Record<string, unknown>;
+    if (!parsed.route && !parsed.provider_backend) return null;
+    return {
+      route: parsed.route as string | undefined,
+      provider_backend: parsed.provider_backend as string | undefined,
+      capability_lane: parsed.capability_lane as string | undefined,
+      execution_mode: parsed.execution_mode as string | undefined,
+      availability_status: parsed.availability_status as string | undefined,
+      confidence: parsed.confidence as number | undefined,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/dashboard/src/components/ProjectView.tsx
+++ b/dashboard/src/components/ProjectView.tsx
@@ -10,6 +10,9 @@ import { SessionLauncher } from './SessionLauncher';
 import { WebPageView } from './WebPageView';
 import { api } from '../lib/api';
 import { CloseTabModal } from './CloseTabModal';
+import { SkillsPanel } from './SkillsPanel';
+import { CommandPalette } from './CommandPalette';
+import { SkillSuggestBar } from './SkillSuggestBar';
 
 interface ProjectViewProps {
   projectId: string;
@@ -41,7 +44,7 @@ interface WebPageInstance {
   url: string;
 }
 
-type ActiveMode = 'terminal' | 'explorer' | 'events' | 'git';
+type ActiveMode = 'terminal' | 'explorer' | 'events' | 'git' | 'skills';
 
 interface PersistedState {
   activeMode: ActiveMode;
@@ -99,6 +102,7 @@ const sidebarButtons = [
   { id: 'terminal' as const, icon: Monitor, title: 'Terminal' },
   { id: 'explorer' as const, icon: FolderTree, title: 'File Explorer' },
   { id: 'git' as const, icon: GitBranch, title: 'Source Control' },
+  { id: 'skills' as const, icon: Zap, title: 'Skills' },
 ] as const;
 
 export function ProjectView({ projectId, projectPath, projectName: _projectName, active = true, terminalsSuspended = false, focusSessionId, onFocusSessionHandled, onHiddenSessionsChange }: ProjectViewProps) {
@@ -822,7 +826,8 @@ export function ProjectView({ projectId, projectPath, projectName: _projectName,
   const gridHiddenCount = hiddenSessions.length;
 
   return (
-    <div className="h-full flex">
+    <div className="h-full flex flex-col">
+    <div className="flex flex-1 min-h-0">
       {/* Icon sidebar */}
       <div
         className="flex flex-col items-center py-2 gap-1 shrink-0"
@@ -1580,7 +1585,14 @@ export function ProjectView({ projectId, projectPath, projectName: _projectName,
             </div>
           ))}
 
-          {/* Events panel */}
+          {/* Skills panel */}
+          <div
+            className="h-full absolute inset-0"
+            style={{ display: activeMode === 'skills' ? 'block' : 'none' }}
+          >
+            <SkillsPanel projectId={projectId} projectPath={projectPath} />
+          </div>
+
           {/* Git panel */}
           <div
             className="h-full absolute inset-0"
@@ -1607,6 +1619,12 @@ export function ProjectView({ projectId, projectPath, projectName: _projectName,
           onCancel={() => setCloseConfirm(null)}
         />
       )}
+
+      {/* Command Palette (Ctrl+K) */}
+      <CommandPalette projectPath={projectPath} />
+    </div>
+    {/* Live Skill Suggestion Bar */}
+    <SkillSuggestBar projectPath={projectPath} projectId={projectId} />
     </div>
   );
 }

--- a/dashboard/src/components/SessionReplay.tsx
+++ b/dashboard/src/components/SessionReplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 interface TranscriptEntry {
   seq: number;

--- a/dashboard/src/components/SessionReplay.tsx
+++ b/dashboard/src/components/SessionReplay.tsx
@@ -1,0 +1,175 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+interface TranscriptEntry {
+  seq: number;
+  role: string;
+  content: string | null;
+  tool_name: string | null;
+  tokens_in?: number;
+  tokens_out?: number;
+  cost_usd?: number;
+  timestamp: string;
+}
+
+interface SessionReplayProps {
+  sessionId: string;
+  apiBase?: string;
+}
+
+const ROLE_COLORS: Record<string, string> = {
+  user: '#4CAF50',
+  assistant: '#2196F3',
+  system: '#9E9E9E',
+  tool_use: '#FF9800',
+  tool_result: '#FF5722',
+};
+
+export default function SessionReplay({ sessionId, apiBase = '' }: SessionReplayProps) {
+  const [entries, setEntries] = useState<TranscriptEntry[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [playSpeed, setPlaySpeed] = useState(1000); // ms between steps
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`${apiBase}/api/sessions/${sessionId}/replay`)
+      .then(res => res.json())
+      .then(data => {
+        if (data.ok) {
+          setEntries(data.entries || []);
+        } else {
+          setError(data.error || 'Failed to load transcript');
+        }
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(String(err));
+        setLoading(false);
+      });
+  }, [sessionId, apiBase]);
+
+  // Auto-play timer
+  useEffect(() => {
+    if (!isPlaying || currentIndex >= entries.length - 1) {
+      setIsPlaying(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setCurrentIndex(i => Math.min(i + 1, entries.length - 1));
+    }, playSpeed);
+    return () => clearTimeout(timer);
+  }, [isPlaying, currentIndex, entries.length, playSpeed]);
+
+  const togglePlay = useCallback(() => {
+    if (currentIndex >= entries.length - 1) {
+      setCurrentIndex(0);
+    }
+    setIsPlaying(p => !p);
+  }, [currentIndex, entries.length]);
+
+  if (loading) return <div style={{ padding: 16 }}>Loading transcript...</div>;
+  if (error) return <div style={{ padding: 16, color: '#f44336' }}>Error: {error}</div>;
+  if (entries.length === 0) return <div style={{ padding: 16 }}>No transcript entries found.</div>;
+
+  const visibleEntries = entries.slice(0, currentIndex + 1);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', fontFamily: 'monospace' }}>
+      {/* Controls */}
+      <div style={{
+        padding: '8px 16px',
+        borderBottom: '1px solid #333',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        background: '#1a1a1a',
+      }}>
+        <button onClick={togglePlay} style={{ padding: '4px 12px', cursor: 'pointer' }}>
+          {isPlaying ? 'Pause' : 'Play'}
+        </button>
+        <button
+          onClick={() => setCurrentIndex(i => Math.max(0, i - 1))}
+          disabled={currentIndex === 0}
+          style={{ padding: '4px 8px', cursor: 'pointer' }}
+        >
+          Prev
+        </button>
+        <button
+          onClick={() => setCurrentIndex(i => Math.min(entries.length - 1, i + 1))}
+          disabled={currentIndex >= entries.length - 1}
+          style={{ padding: '4px 8px', cursor: 'pointer' }}
+        >
+          Next
+        </button>
+        <span style={{ color: '#aaa', fontSize: 12 }}>
+          Step {currentIndex + 1} / {entries.length}
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={entries.length - 1}
+          value={currentIndex}
+          onChange={e => { setCurrentIndex(Number(e.target.value)); setIsPlaying(false); }}
+          style={{ flex: 1 }}
+        />
+        <select
+          value={playSpeed}
+          onChange={e => setPlaySpeed(Number(e.target.value))}
+          style={{ padding: '2px 4px' }}
+        >
+          <option value={2000}>0.5x</option>
+          <option value={1000}>1x</option>
+          <option value={500}>2x</option>
+          <option value={200}>5x</option>
+        </select>
+      </div>
+
+      {/* Transcript */}
+      <div style={{ flex: 1, overflow: 'auto', padding: 16 }}>
+        {visibleEntries.map((entry, i) => (
+          <div
+            key={entry.seq || i}
+            style={{
+              marginBottom: 8,
+              padding: '8px 12px',
+              borderLeft: `3px solid ${ROLE_COLORS[entry.role] || '#666'}`,
+              background: i === currentIndex ? '#2a2a2a' : 'transparent',
+              borderRadius: 4,
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+              <span style={{
+                color: ROLE_COLORS[entry.role] || '#666',
+                fontWeight: 'bold',
+                fontSize: 12,
+                textTransform: 'uppercase',
+              }}>
+                {entry.role}
+                {entry.tool_name && ` (${entry.tool_name})`}
+              </span>
+              <span style={{ color: '#666', fontSize: 11 }}>
+                {entry.timestamp}
+                {entry.tokens_in || entry.tokens_out ?
+                  ` | ${entry.tokens_in || 0} in / ${entry.tokens_out || 0} out` : ''}
+                {entry.cost_usd ? ` | $${entry.cost_usd.toFixed(4)}` : ''}
+              </span>
+            </div>
+            <pre style={{
+              margin: 0,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              fontSize: 13,
+              color: '#ddd',
+              maxHeight: 300,
+              overflow: 'auto',
+            }}>
+              {typeof entry.content === 'string' ? entry.content : JSON.stringify(entry.content, null, 2)}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/SkillSuggestBar.tsx
+++ b/dashboard/src/components/SkillSuggestBar.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Zap, ChevronUp, X } from 'lucide-react';
+import { api } from '../lib/api';
+import { searchSlash, searchIntent, recordSkillUsage } from '../lib/fuzzy';
+import type { IntentEntry } from '../lib/fuzzy';
+import type { SkillItem } from '../types/skills';
+
+interface SkillSuggestBarProps {
+  projectPath: string;
+  projectId?: string;
+}
+
+export function SkillSuggestBar({ projectPath }: SkillSuggestBarProps) {
+  const [skills, setSkills] = useState<SkillItem[]>([]);
+  const [intentMap, setIntentMap] = useState<IntentEntry[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [inputBuffer, setInputBuffer] = useState('');
+  const [expanded, setExpanded] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+  // Track recently clicked skills to boost related suggestions
+  const [clickedSkillIds, setClickedSkillIds] = useState<string[]>([]);
+
+  // Load skills + intent map once
+  useEffect(() => {
+    if (loaded) return;
+    Promise.all([
+      api.skills.list(projectPath),
+      api.skills.intents(projectPath),
+    ])
+      .then(([skillsData, intentsData]) => {
+        setSkills(skillsData.skills);
+        setIntentMap(intentsData.intents);
+        setLoaded(true);
+      })
+      .catch(() => {});
+  }, [projectPath, loaded]);
+
+  useEffect(() => { setLoaded(false); }, [projectPath]);
+
+  // Listen for terminal input buffer events
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const buf = (e as CustomEvent).detail?.buffer;
+      if (typeof buf === 'string') {
+        setInputBuffer(buf);
+        setSelectedIndex(0);
+        if (buf.length <= 1) {
+          setDismissed(false);
+          setClickedSkillIds([]);
+        }
+      }
+    };
+    window.addEventListener('octoally:input-buffer', handler);
+    return () => window.removeEventListener('octoally:input-buffer', handler);
+  }, []);
+
+  const isSlashMode = inputBuffer.startsWith('/');
+  const slashQuery = isSlashMode ? inputBuffer.slice(1) : '';
+  // Always show more when skills have been clicked (user is exploring)
+  const limit = expanded ? 20 : clickedSkillIds.length > 0 ? 8 : 5;
+
+  // Build a set of categories/intents from clicked skills to boost related ones
+  const clickBoostContext = useMemo(() => {
+    if (clickedSkillIds.length === 0) return null;
+    const categories = new Set<string>();
+    const intentWords = new Set<string>();
+    for (const id of clickedSkillIds) {
+      const entry = intentMap.find(e => e.command === `/${id}` || e.name === id);
+      if (entry) {
+        categories.add(entry.category);
+        for (const intent of entry.intents) {
+          for (const w of intent.split(/\s+/)) {
+            if (w.length > 2) intentWords.add(w);
+          }
+        }
+      }
+    }
+    return { categories, intentWords };
+  }, [clickedSkillIds, intentMap]);
+
+  // Intent map results (instant, client-side)
+  const suggestions = useMemo(() => {
+    if (dismissed || skills.length === 0) return [];
+
+    if (isSlashMode && slashQuery.length > 0) {
+      return searchSlash(skills, slashQuery, limit).map(r => ({
+        skill: r.skill,
+        reason: r.skill.description || '',
+        clicked: clickedSkillIds.includes(r.skill.id),
+      }));
+    }
+
+    if (!isSlashMode && inputBuffer.length >= 3 && intentMap.length > 0) {
+      let results = searchIntent(intentMap, skills, inputBuffer, limit + 5);
+
+      // Boost related skills when user has clicked some
+      if (clickBoostContext && results.length > 0) {
+        results = results.map(r => {
+          const entry = intentMap.find(e => e.command === r.skill.command);
+          if (!entry) return r;
+
+          let boost = 1.0;
+          // Same category as clicked skill → boost
+          if (clickBoostContext.categories.has(entry.category)) boost += 0.5;
+          // Shared intent words → boost
+          let sharedWords = 0;
+          for (const intent of entry.intents) {
+            for (const w of intent.split(/\s+/)) {
+              if (clickBoostContext.intentWords.has(w)) sharedWords++;
+            }
+          }
+          boost += Math.min(sharedWords * 0.1, 0.8);
+
+          return { ...r, score: r.score * boost };
+        });
+        results.sort((a, b) => b.score - a.score);
+      }
+
+      // Filter out already-clicked skills (they're already in the prompt)
+      const alreadyClicked = new Set(clickedSkillIds);
+      return results
+        .filter(r => !alreadyClicked.has(r.skill.id))
+        .slice(0, limit)
+        .map(r => ({
+          skill: r.skill,
+          reason: r.reason || r.skill.description || '',
+          clicked: false,
+        }));
+    }
+
+    return [];
+  }, [skills, intentMap, isSlashMode, slashQuery, inputBuffer, limit, dismissed, clickedSkillIds, clickBoostContext]);
+
+  useEffect(() => { setSelectedIndex(0); }, [suggestions.length]);
+
+  const invoke = useCallback((skill: SkillItem) => {
+    recordSkillUsage(skill.id);
+    const prefix = inputBuffer.length > 0 && !inputBuffer.endsWith(' ') ? ' ' : '';
+    window.dispatchEvent(new CustomEvent('octoally:skill-invoke', {
+      detail: { command: prefix + skill.command + ' ', execute: false },
+    }));
+    // Don't dismiss — keep suggestions visible, track what was clicked
+    setClickedSkillIds(prev => prev.includes(skill.id) ? prev : [...prev, skill.id]);
+    setSelectedIndex(0);
+  }, [inputBuffer]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (suggestions.length === 0) return;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex(prev => Math.min(prev + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex(prev => Math.max(prev - 1, 0));
+    } else if (e.key === 'Enter' && suggestions[selectedIndex]) {
+      e.preventDefault();
+      invoke(suggestions[selectedIndex].skill);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setExpanded(false);
+      setDismissed(true);
+      setClickedSkillIds([]);
+    }
+  }, [suggestions, selectedIndex, invoke]);
+
+  const showSuggestions = suggestions.length > 0;
+  const sourceLabel = isSlashMode ? 'command' : clickedSkillIds.length > 0 ? 'related' : 'intent';
+
+  return (
+    <div
+      className="shrink-0"
+      style={{ borderTop: '1px solid var(--border)', background: 'var(--bg-secondary)' }}
+      onKeyDown={handleKeyDown}
+    >
+      {/* Expanded popover */}
+      {expanded && showSuggestions && (
+        <div
+          className="px-2 py-1 space-y-0 max-h-[180px] overflow-y-auto"
+          style={{ borderBottom: '1px solid var(--border)' }}
+        >
+          {suggestions.slice(5).map(({ skill, reason }, i) => (
+            <button
+              key={skill.id}
+              onClick={() => invoke(skill)}
+              className="w-full flex items-center gap-1.5 px-1.5 py-0.5 rounded text-left transition-colors"
+              style={{
+                minHeight: 24,
+                background: (i + 5) === selectedIndex ? 'var(--bg-tertiary)' : 'transparent',
+              }}
+              onMouseEnter={() => setSelectedIndex(i + 5)}
+            >
+              <span className="text-[11px] font-medium" style={{ color: 'var(--text-primary)' }}>
+                {skill.command}
+              </span>
+              <span className="text-[9px] truncate" style={{ color: 'var(--text-tertiary)' }}>
+                {reason}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Main bar */}
+      <div className="flex items-center gap-1 px-2" style={{ height: 28 }}>
+        <Zap
+          className="w-3 h-3 shrink-0"
+          style={{ color: showSuggestions ? 'var(--accent)' : 'var(--text-tertiary)' }}
+        />
+
+        {showSuggestions ? (
+          <>
+            <span
+              className="shrink-0 text-[8px] px-1 py-0 rounded font-medium uppercase leading-none"
+              style={{
+                background: sourceLabel === 'related' ? 'var(--accent)' : 'var(--bg-tertiary)',
+                color: sourceLabel === 'related' ? 'white' : 'var(--text-secondary)',
+                border: sourceLabel === 'related' ? 'none' : '1px solid var(--border)',
+              }}
+            >
+              {sourceLabel}
+            </span>
+
+            <div className="flex items-center gap-1 flex-1 overflow-x-auto" role="listbox">
+              {suggestions.slice(0, 5).map(({ skill, reason }, i) => (
+                <button
+                  key={skill.id}
+                  role="option"
+                  aria-selected={i === selectedIndex}
+                  onClick={() => invoke(skill)}
+                  onMouseEnter={() => setSelectedIndex(i)}
+                  className="shrink-0 flex items-center gap-1 px-2 py-0 rounded-full text-[11px] font-medium transition-colors whitespace-nowrap"
+                  style={{
+                    minHeight: 20,
+                    lineHeight: '20px',
+                    background: i === selectedIndex ? 'var(--accent)' : 'var(--bg-tertiary)',
+                    color: i === selectedIndex ? 'white' : 'var(--text-primary)',
+                    border: `1px solid ${i === selectedIndex ? 'var(--accent)' : 'var(--border)'}`,
+                  }}
+                  title={reason || skill.description || skill.id}
+                >
+                  {skill.command}
+                </button>
+              ))}
+            </div>
+
+            {suggestions.length > 5 && (
+              <button
+                onClick={() => setExpanded(prev => !prev)}
+                className="shrink-0 p-0.5 rounded transition-colors"
+                style={{ color: 'var(--text-tertiary)' }}
+                title={`${suggestions.length - 5} more`}
+              >
+                <ChevronUp
+                  className="w-3 h-3 transition-transform"
+                  style={{ transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)' }}
+                />
+              </button>
+            )}
+
+            <button
+              onClick={() => { setDismissed(true); setExpanded(false); setClickedSkillIds([]); }}
+              className="shrink-0 p-0.5 rounded transition-colors"
+              style={{ color: 'var(--text-tertiary)' }}
+              aria-label="Dismiss suggestions"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </>
+        ) : (
+          <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+            {dismissed
+              ? 'Suggestions dismissed'
+              : isSlashMode && slashQuery.length > 0
+                ? `No skills match "/${slashQuery}"`
+                : 'Skills suggested as you type'}
+          </span>
+        )}
+
+        {showSuggestions && (
+          <span className="shrink-0 text-[9px] ml-0.5" style={{ color: 'var(--text-tertiary)' }}>
+            {clickedSkillIds.length > 0 ? `${clickedSkillIds.length} added` : 'click to add'}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/SkillSuggestBar.tsx
+++ b/dashboard/src/components/SkillSuggestBar.tsx
@@ -1,9 +1,33 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { Zap, ChevronUp, X } from 'lucide-react';
+import { Zap, ChevronUp, X, Cpu } from 'lucide-react';
 import { api } from '../lib/api';
 import { searchSlash, searchIntent, recordSkillUsage } from '../lib/fuzzy';
 import type { IntentEntry } from '../lib/fuzzy';
 import type { SkillItem } from '../types/skills';
+
+type GpuState = 'gpu' | 'cpu' | 'off' | 'loading';
+
+function useGpuStatus(pollMs = 30000): GpuState {
+  const [state, setState] = useState<GpuState>('loading');
+  useEffect(() => {
+    let mounted = true;
+    const check = () => {
+      fetch('/api/system/status')
+        .then(r => r.json())
+        .then(data => {
+          if (!mounted) return;
+          const ollama = data.integrations?.find((i: any) => i.id === 'ollama');
+          if (!ollama || !ollama.connected) setState('off');
+          else setState(ollama.details?.gpu ? 'gpu' : 'cpu');
+        })
+        .catch(() => mounted && setState('off'));
+    };
+    check();
+    const id = setInterval(check, pollMs);
+    return () => { mounted = false; clearInterval(id); };
+  }, [pollMs]);
+  return state;
+}
 
 interface SkillSuggestBarProps {
   projectPath: string;
@@ -166,6 +190,7 @@ export function SkillSuggestBar({ projectPath }: SkillSuggestBarProps) {
 
   const showSuggestions = suggestions.length > 0;
   const sourceLabel = isSlashMode ? 'command' : clickedSkillIds.length > 0 ? 'related' : 'intent';
+  const gpuState = useGpuStatus();
 
   return (
     <div
@@ -282,6 +307,25 @@ export function SkillSuggestBar({ projectPath }: SkillSuggestBarProps) {
             {clickedSkillIds.length > 0 ? `${clickedSkillIds.length} added` : 'click to add'}
           </span>
         )}
+
+        {/* GPU/CPU indicator — always visible */}
+        <span
+          className="shrink-0 ml-auto flex items-center gap-0.5 text-[9px] font-medium px-1.5 rounded-full"
+          style={{
+            background: gpuState === 'gpu' ? 'rgba(34,197,94,0.15)' : gpuState === 'cpu' ? 'rgba(234,179,8,0.15)' : 'var(--bg-tertiary)',
+            color: gpuState === 'gpu' ? '#22c55e' : gpuState === 'cpu' ? '#eab308' : 'var(--text-tertiary)',
+            border: `1px solid ${gpuState === 'gpu' ? 'rgba(34,197,94,0.3)' : gpuState === 'cpu' ? 'rgba(234,179,8,0.3)' : 'var(--border)'}`,
+            lineHeight: '16px',
+          }}
+          title={
+            gpuState === 'gpu' ? 'Ollama via GPU tunnel (ROG_Beast RTX 5070 Ti)'
+            : gpuState === 'cpu' ? 'Ollama local CPU fallback'
+            : 'Ollama offline'
+          }
+        >
+          <Cpu className="w-2.5 h-2.5" />
+          {gpuState === 'gpu' ? 'GPU' : gpuState === 'cpu' ? 'CPU' : 'OFF'}
+        </span>
       </div>
     </div>
   );

--- a/dashboard/src/components/SkillsPanel.tsx
+++ b/dashboard/src/components/SkillsPanel.tsx
@@ -1,0 +1,530 @@
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import {
+  Search, X, Star, ChevronRight, ChevronDown, Circle,
+  ToggleLeft, ToggleRight, RefreshCw,
+} from 'lucide-react';
+import { api } from '../lib/api';
+import type { SkillItem, SystemFeature, Integration } from '../types/skills';
+
+type Tab = 'skills' | 'system' | 'integrations';
+
+// --- Storage helpers ---
+
+const STORAGE_PREFIX = 'octoally-skills-';
+
+function loadPins(projectId: string): string[] {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${projectId}-pins`);
+    return raw ? JSON.parse(raw) : [];
+  } catch { return []; }
+}
+
+function savePins(projectId: string, pins: string[]) {
+  localStorage.setItem(`${STORAGE_PREFIX}${projectId}-pins`, JSON.stringify(pins));
+}
+
+function loadRecent(projectId: string): string[] {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${projectId}-recent`);
+    return raw ? JSON.parse(raw) : [];
+  } catch { return []; }
+}
+
+function saveRecent(projectId: string, recent: string[]) {
+  localStorage.setItem(`${STORAGE_PREFIX}${projectId}-recent`, JSON.stringify(recent.slice(0, 10)));
+}
+
+function loadFrequency(projectId: string): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${projectId}-freq`);
+    return raw ? JSON.parse(raw) : {};
+  } catch { return {}; }
+}
+
+function saveFrequency(projectId: string, freq: Record<string, number>) {
+  localStorage.setItem(`${STORAGE_PREFIX}${projectId}-freq`, JSON.stringify(freq));
+}
+
+// --- Category color ---
+
+const CATEGORY_COLORS = [
+  '#3b82f6', '#8b5cf6', '#ec4899', '#f59e0b', '#22c55e',
+  '#06b6d4', '#f97316', '#6366f1', '#14b8a6', '#e11d48',
+  '#a855f7', '#84cc16',
+];
+
+function categoryColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  return CATEGORY_COLORS[Math.abs(hash) % CATEGORY_COLORS.length];
+}
+
+// --- Fuzzy score ---
+
+function scoreSkill(skill: SkillItem, query: string, freq: Record<string, number>, recent: string[]): number {
+  const q = query.toLowerCase();
+  const name = skill.id.toLowerCase();
+  let score = 0;
+  if (name.startsWith(q)) score += 100;
+  else if (name.includes(q)) score += 50;
+  else if (skill.category.toLowerCase().includes(q)) score += 25;
+  else if (skill.description?.toLowerCase().includes(q)) score += 10;
+  else return -1; // no match
+  score += (freq[skill.id] || 0) * 2;
+  if (recent.includes(skill.id)) score += 10;
+  return score;
+}
+
+// --- Component ---
+
+interface SkillsPanelProps {
+  projectId: string;
+  projectPath: string;
+}
+
+export function SkillsPanel({ projectId, projectPath }: SkillsPanelProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('skills');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [skills, setSkills] = useState<SkillItem[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [features, setFeatures] = useState<SystemFeature[]>([]);
+  const [integrations, setIntegrations] = useState<Integration[]>([]);
+  const [expandedCats, setExpandedCats] = useState<Set<string>>(new Set());
+  const [expandedFeature, setExpandedFeature] = useState<string | null>(null);
+  const [pins, setPins] = useState<string[]>(() => loadPins(projectId));
+  const [recent, setRecent] = useState<string[]>(() => loadRecent(projectId));
+  const [freq, setFreq] = useState<Record<string, number>>(() => loadFrequency(projectId));
+  const [loading, setLoading] = useState(true);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; skillId: string } | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Reload personalization on project switch
+  useEffect(() => {
+    setPins(loadPins(projectId));
+    setRecent(loadRecent(projectId));
+    setFreq(loadFrequency(projectId));
+  }, [projectId]);
+
+  // Fetch skills
+  useEffect(() => {
+    setLoading(true);
+    api.skills.list(projectPath)
+      .then(data => {
+        setSkills(data.skills);
+        setCategories(data.categories);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [projectPath]);
+
+  // Fetch system status
+  useEffect(() => {
+    api.skills.systemStatus()
+      .then(data => {
+        setFeatures(data.features);
+        setIntegrations(data.integrations);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Close context menu on click outside
+  useEffect(() => {
+    if (!contextMenu) return;
+    const handler = () => setContextMenu(null);
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, [contextMenu]);
+
+  // Keyboard: / to focus search
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === '/' && document.activeElement?.tagName !== 'INPUT') {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
+
+  const toggleCategory = useCallback((cat: string) => {
+    setExpandedCats(prev => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat); else next.add(cat);
+      return next;
+    });
+  }, []);
+
+  const invokeSkill = useCallback((skill: SkillItem) => {
+    // Send to active terminal via OctoAlly's terminal write mechanism
+    // We dispatch a custom event that Terminal.tsx can listen for
+    window.dispatchEvent(new CustomEvent('octoally:skill-invoke', {
+      detail: { command: skill.command },
+    }));
+
+    // Update recent
+    setRecent(prev => {
+      const next = [skill.id, ...prev.filter(id => id !== skill.id)].slice(0, 10);
+      saveRecent(projectId, next);
+      return next;
+    });
+
+    // Update frequency
+    setFreq(prev => {
+      const next = { ...prev, [skill.id]: (prev[skill.id] || 0) + 1 };
+      saveFrequency(projectId, next);
+      return next;
+    });
+  }, [projectId]);
+
+  const togglePin = useCallback((skillId: string) => {
+    setPins(prev => {
+      const next = prev.includes(skillId)
+        ? prev.filter(id => id !== skillId)
+        : [...prev, skillId];
+      savePins(projectId, next);
+      return next;
+    });
+    setContextMenu(null);
+  }, [projectId]);
+
+  // Filtered/scored skills for search
+  const filteredSkills = useMemo(() => {
+    if (!searchQuery.trim()) return null;
+    return skills
+      .map(s => ({ skill: s, score: scoreSkill(s, searchQuery.trim(), freq, recent) }))
+      .filter(({ score }) => score >= 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 50)
+      .map(({ skill }) => skill);
+  }, [skills, searchQuery, freq, recent]);
+
+  // Grouped skills by category
+  const grouped = useMemo(() => {
+    const map = new Map<string, SkillItem[]>();
+    for (const s of skills) {
+      if (!map.has(s.category)) map.set(s.category, []);
+      map.get(s.category)!.push(s);
+    }
+    return map;
+  }, [skills]);
+
+  const pinnedSkills = useMemo(
+    () => pins.map(id => skills.find(s => s.id === id)).filter(Boolean) as SkillItem[],
+    [pins, skills]
+  );
+
+  const recentSkills = useMemo(
+    () => recent.map(id => skills.find(s => s.id === id)).filter(Boolean).slice(0, 5) as SkillItem[],
+    [recent, skills]
+  );
+
+  const statusColor = (status: string) => {
+    if (status === 'ok') return '#22c55e';
+    if (status === 'error') return '#ef4444';
+    if (status === 'degraded') return '#f59e0b';
+    return 'var(--text-tertiary)';
+  };
+
+  const renderSkillRow = (skill: SkillItem, showCategory = false) => (
+    <button
+      key={skill.id}
+      onClick={() => invokeSkill(skill)}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setContextMenu({ x: e.clientX, y: e.clientY, skillId: skill.id });
+      }}
+      className="w-full flex items-center gap-2 px-3 py-2.5 text-left rounded-md transition-colors group"
+      style={{ minHeight: 44 }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-tertiary)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+    >
+      {pins.includes(skill.id) ? (
+        <Star className="w-3.5 h-3.5 shrink-0" style={{ color: '#f59e0b', fill: '#f59e0b' }} />
+      ) : (
+        <Circle className="w-2 h-2 shrink-0" style={{ color: categoryColor(skill.category), fill: categoryColor(skill.category) }} />
+      )}
+      <span className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+        {skill.command}
+      </span>
+      {showCategory && (
+        <span className="text-[10px] ml-auto shrink-0" style={{ color: 'var(--text-tertiary)' }}>
+          {skill.category}
+        </span>
+      )}
+      {skill.scope === 'project' && (
+        <span
+          className="text-[9px] px-1 py-0.5 rounded shrink-0"
+          style={{ background: 'var(--bg-tertiary)', color: 'var(--text-secondary)' }}
+        >
+          project
+        </span>
+      )}
+    </button>
+  );
+
+  return (
+    <div className="h-full flex flex-col" style={{ background: 'var(--bg-primary)' }}>
+      {/* Search */}
+      <div className="px-3 pt-3 pb-2">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5" style={{ color: 'var(--text-tertiary)' }} />
+          <input
+            ref={searchRef}
+            type="text"
+            placeholder="Search skills... (press /)"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            aria-label="Search skills"
+            className="w-full pl-8 pr-8 py-1.5 rounded-md text-sm focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            style={{
+              background: 'var(--bg-secondary)',
+              border: '1px solid var(--border)',
+              color: 'var(--text-primary)',
+            }}
+            onFocus={(e) => (e.currentTarget.style.borderColor = 'var(--accent)')}
+            onBlur={(e) => (e.currentTarget.style.borderColor = 'var(--border)')}
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2"
+              style={{ color: 'var(--text-tertiary)' }}
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div role="tablist" className="flex gap-0.5 px-3 pb-2" style={{ borderBottom: '1px solid var(--border)' }}>
+        {(['skills', 'system', 'integrations'] as Tab[]).map(tab => (
+          <button
+            key={tab}
+            role="tab"
+            aria-selected={activeTab === tab}
+            onClick={() => { setActiveTab(tab); setSearchQuery(''); }}
+            className="px-3 py-1 rounded-md text-xs font-medium transition-colors capitalize"
+            style={{
+              background: activeTab === tab ? 'var(--bg-tertiary)' : 'transparent',
+              color: activeTab === tab ? 'var(--text-primary)' : 'var(--text-secondary)',
+            }}
+          >
+            {tab}
+          </button>
+        ))}
+        <span className="ml-auto text-[10px] self-center" style={{ color: 'var(--text-tertiary)' }}>
+          {skills.length} skills
+        </span>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-1 py-1">
+        {loading ? (
+          <div className="flex items-center justify-center h-32" style={{ color: 'var(--text-tertiary)' }}>
+            <RefreshCw className="w-4 h-4 animate-spin mr-2" />
+            <span className="text-sm">Loading skills...</span>
+          </div>
+        ) : activeTab === 'skills' ? (
+          <>
+            {/* Search results mode */}
+            {filteredSkills ? (
+              <div className="py-1">
+                <div className="px-3 py-1 text-[10px] uppercase tracking-wider font-semibold" style={{ color: 'var(--text-tertiary)' }}>
+                  Results ({filteredSkills.length})
+                </div>
+                {filteredSkills.length === 0 ? (
+                  <div className="px-3 py-4 text-sm italic" style={{ color: 'var(--text-tertiary)' }}>
+                    No skills match "{searchQuery}"
+                  </div>
+                ) : (
+                  filteredSkills.map(s => renderSkillRow(s, true))
+                )}
+              </div>
+            ) : (
+              <>
+                {/* Pinned */}
+                <div className="py-1">
+                  <div className="px-3 py-1 text-[10px] uppercase tracking-wider font-semibold" style={{ color: 'var(--text-tertiary)' }}>
+                    Pinned ({pinnedSkills.length})
+                  </div>
+                  {pinnedSkills.length === 0 ? (
+                    <div className="px-3 py-2 text-xs italic" style={{ color: 'var(--text-tertiary)' }}>
+                      Right-click any skill to pin it here
+                    </div>
+                  ) : (
+                    pinnedSkills.map(s => renderSkillRow(s))
+                  )}
+                </div>
+
+                {/* Recent */}
+                {recentSkills.length > 0 && (
+                  <div className="py-1">
+                    <div className="px-3 py-1 text-[10px] uppercase tracking-wider font-semibold" style={{ color: 'var(--text-tertiary)' }}>
+                      Recent ({recentSkills.length})
+                    </div>
+                    {recentSkills.map(s => renderSkillRow(s))}
+                  </div>
+                )}
+
+                {/* Categories */}
+                {categories.map(cat => {
+                  const items = grouped.get(cat) || [];
+                  const isExpanded = expandedCats.has(cat);
+                  return (
+                    <div key={cat} className="py-0.5" style={{ contentVisibility: 'auto' }}>
+                      <button
+                        onClick={() => toggleCategory(cat)}
+                        aria-expanded={isExpanded}
+                        className="w-full flex items-center gap-1.5 px-3 py-2 text-left"
+                        style={{ minHeight: 44 }}
+                      >
+                        {isExpanded
+                          ? <ChevronDown className="w-3 h-3 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
+                          : <ChevronRight className="w-3 h-3 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
+                        }
+                        <span
+                          className="w-1.5 h-1.5 rounded-full shrink-0"
+                          style={{ background: categoryColor(cat) }}
+                        />
+                        <span className="text-[11px] uppercase tracking-wider font-semibold" style={{ color: 'var(--text-tertiary)' }}>
+                          {cat}
+                        </span>
+                        <span className="text-[10px] ml-1" style={{ color: 'var(--text-tertiary)' }}>
+                          ({items.length})
+                        </span>
+                      </button>
+                      {isExpanded && items.map(s => renderSkillRow(s))}
+                    </div>
+                  );
+                })}
+              </>
+            )}
+          </>
+        ) : activeTab === 'system' ? (
+          <div className="py-1 space-y-1">
+            {features.length === 0 ? (
+              <div className="px-3 py-4 text-sm italic" style={{ color: 'var(--text-tertiary)' }}>
+                No system features detected
+              </div>
+            ) : (
+              features.map(feat => (
+                <div key={feat.id} className="mx-2 rounded-lg" style={{ border: '1px solid var(--border)' }}>
+                  <button
+                    onClick={() => setExpandedFeature(expandedFeature === feat.id ? null : feat.id)}
+                    className="w-full flex items-center gap-3 px-3 py-2.5"
+                    style={{
+                      borderLeft: `2px solid ${statusColor(feat.status)}`,
+                      borderRadius: 'inherit',
+                    }}
+                  >
+                    <Circle
+                      className="w-3 h-3 shrink-0"
+                      style={{ color: statusColor(feat.status), fill: statusColor(feat.status) }}
+                    />
+                    <div className="flex-1 text-left">
+                      <div className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{feat.name}</div>
+                      <div className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>{feat.description}</div>
+                    </div>
+                    {feat.enabled ? (
+                      <ToggleRight className="w-5 h-5 shrink-0" style={{ color: '#22c55e' }} />
+                    ) : (
+                      <ToggleLeft className="w-5 h-5 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
+                    )}
+                  </button>
+                  {expandedFeature === feat.id && feat.details && (
+                    <div className="px-3 pb-2 pt-1 text-[11px] space-y-0.5" style={{ color: 'var(--text-secondary)', borderTop: '1px solid var(--border)' }}>
+                      {Object.entries(feat.details).map(([k, v]) => (
+                        <div key={k}><span className="font-medium">{k}:</span> {v}</div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        ) : (
+          /* Integrations tab */
+          <div className="py-1 space-y-1">
+            {integrations.length === 0 ? (
+              <div className="px-3 py-4 text-sm italic" style={{ color: 'var(--text-tertiary)' }}>
+                No integrations configured
+              </div>
+            ) : (
+              integrations.map(intg => (
+                <div
+                  key={intg.id}
+                  className="mx-2 flex items-center gap-3 px-3 py-2.5 rounded-lg"
+                  style={{
+                    border: '1px solid var(--border)',
+                    borderLeft: `2px solid ${statusColor(intg.status)}`,
+                  }}
+                >
+                  <Circle
+                    className="w-3 h-3 shrink-0"
+                    style={{ color: statusColor(intg.status), fill: intg.connected ? statusColor(intg.status) : 'transparent' }}
+                  />
+                  <div className="flex-1">
+                    <div className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{intg.name}</div>
+                    <div className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+                      {intg.connected ? 'Connected' : 'Disconnected'}
+                    </div>
+                  </div>
+                  <span
+                    className="text-[10px] px-2 py-0.5 rounded-full font-medium"
+                    style={{
+                      background: intg.connected ? '#16a34a22' : '#dc262622',
+                      color: intg.connected ? '#22c55e' : '#ef4444',
+                    }}
+                  >
+                    {intg.status}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Context menu */}
+      {contextMenu && (
+        <div
+          role="menu"
+          className="fixed z-50 rounded-lg shadow-lg py-1 min-w-[160px]"
+          style={{
+            left: contextMenu.x,
+            top: contextMenu.y,
+            background: 'var(--bg-secondary)',
+            border: '1px solid var(--border)',
+          }}
+        >
+          <button
+            role="menuitem"
+            onClick={() => togglePin(contextMenu.skillId)}
+            className="w-full text-left px-3 py-1.5 text-xs font-medium transition-colors"
+            style={{ color: 'var(--text-primary)' }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-tertiary)')}
+            onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          >
+            {pins.includes(contextMenu.skillId) ? 'Unpin' : 'Pin to top'}
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => {
+              const skill = skills.find(s => s.id === contextMenu.skillId);
+              if (skill) navigator.clipboard.writeText(skill.command);
+              setContextMenu(null);
+            }}
+            className="w-full text-left px-3 py-1.5 text-xs font-medium transition-colors"
+            style={{ color: 'var(--text-primary)' }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-tertiary)')}
+            onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          >
+            Copy command
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/Terminal.tsx
+++ b/dashboard/src/components/Terminal.tsx
@@ -327,12 +327,29 @@ export function Terminal({ sessionId, visible = true, suspended = false, passive
     // Send user input to server
     // Filter out xterm.js focus reporting sequences (\x1b[I = focus in, \x1b[O = focus out)
     // These get sent when terminal gains/loses focus and Claude Code's TUI interprets them as input
+    let lineBuffer = '';
     term.onData((data: string) => {
       if (data === '\x1b[I' || data === '\x1b[O') return;
       const w = wsRef.current;
       if (w && w.readyState === WebSocket.OPEN) {
         w.send(JSON.stringify({ type: 'input', data }));
       }
+      // Track line buffer for skill suggestion bar
+      if (data === '\r' || data === '\n') {
+        lineBuffer = '';
+      } else if (data === '\x7f' || data === '\b') {
+        lineBuffer = lineBuffer.slice(0, -1);
+      } else if (data.length === 1 && data.charCodeAt(0) >= 32) {
+        lineBuffer += data;
+      } else if (data.startsWith('\x1b')) {
+        // Escape sequence (arrow keys, etc.) — don't modify buffer
+      } else if (data.length > 1) {
+        // Pasted text
+        lineBuffer += data;
+      }
+      window.dispatchEvent(new CustomEvent('octoally:input-buffer', {
+        detail: { buffer: lineBuffer },
+      }));
     });
 
     term.onBinary((data: string) => {
@@ -677,6 +694,25 @@ export function Terminal({ sessionId, visible = true, suspended = false, passive
       term.options.cursorInactiveStyle = 'outline';
     }
   }, [hideCursor]);
+
+  // Listen for skill-invoke events from the Skills Panel / Command Palette.
+  // Only the visible, non-suspended terminal acts on these.
+  // detail.execute defaults to true; when false, text is typed without Enter.
+  useEffect(() => {
+    if (!visible || suspended) return;
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      const command = detail?.command;
+      if (!command || typeof command !== 'string') return;
+      const w = wsRef.current;
+      if (w && w.readyState === WebSocket.OPEN) {
+        const execute = detail?.execute !== false;
+        w.send(JSON.stringify({ type: 'input', data: execute ? command + '\r' : command }));
+      }
+    };
+    window.addEventListener('octoally:skill-invoke', handler);
+    return () => window.removeEventListener('octoally:skill-invoke', handler);
+  }, [visible, suspended]);
 
   // Re-focus and refit terminal when it becomes visible.
   // Single RAF + short delay ensures DOM layout is settled before measuring.

--- a/dashboard/src/components/Terminal.tsx
+++ b/dashboard/src/components/Terminal.tsx
@@ -259,13 +259,19 @@ export function Terminal({ sessionId, visible = true, suspended = false, passive
       fitAddon.fit();
     });
 
-    // Intercept Ctrl+Shift+C to copy selection
+    // Intercept Ctrl+C: copy selection if text is selected, otherwise send SIGINT
+    // Also keep Ctrl+Shift+C for backward compat
     term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-      if (e.ctrlKey && e.shiftKey && e.key === 'C' && e.type === 'keydown') {
+      if (e.ctrlKey && !e.altKey && !e.metaKey && (e.key === 'c' || e.key === 'C') && e.type === 'keydown') {
         const sel = term.getSelection();
-        if (sel) navigator.clipboard.writeText(sel);
-        e.preventDefault();
-        return false;
+        if (sel) {
+          navigator.clipboard.writeText(sel);
+          term.clearSelection();
+          e.preventDefault();
+          return false;
+        }
+        // No selection — let xterm send SIGINT (^C) as normal
+        if (!e.shiftKey) return true;
       }
       // Ctrl+Shift+V: read clipboard explicitly and send as input.
       // Can't rely on browser firing a paste event — synthetic keystrokes

--- a/dashboard/src/components/ThemeToggle.tsx
+++ b/dashboard/src/components/ThemeToggle.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from 'react';
+import { Palette, Check } from 'lucide-react';
+
+const STORAGE_KEY = 'octoally_theme';
+
+const THEMES = [
+  { id: 'default',    label: 'Default Dark',  bg: '#0f1117', accent: '#3b82f6' },
+  { id: 'cyberpunk',  label: 'Cyberpunk',      bg: '#050a0e', accent: '#00ffcc' },
+  { id: 'nord',       label: 'Nord',           bg: '#2e3440', accent: '#88c0d0' },
+  { id: 'solarized',  label: 'Solarized Dark', bg: '#002b36', accent: '#2aa198' },
+  { id: 'dracula',    label: 'Dracula',        bg: '#282a36', accent: '#bd93f9' },
+  { id: 'monokai',    label: 'Monokai Pro',    bg: '#272822', accent: '#a6e22e' },
+  { id: 'light',      label: 'Light',          bg: '#f7f8fa', accent: '#0969da' },
+  { id: 'sunset',     label: 'Sunset',         bg: '#1a1015', accent: '#ff9e64' },
+] as const;
+
+type ThemeId = (typeof THEMES)[number]['id'];
+
+function loadTheme(): ThemeId {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && THEMES.some((t) => t.id === stored)) return stored as ThemeId;
+  } catch {}
+  return 'default';
+}
+
+function applyTheme(id: ThemeId) {
+  document.documentElement.setAttribute('data-theme', id);
+  try {
+    localStorage.setItem(STORAGE_KEY, id);
+  } catch {}
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<ThemeId>(loadTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  // Apply on initial mount (handles persisted value from a previous session)
+  useEffect(() => {
+    applyTheme(loadTheme());
+  }, []);
+
+  function setTheme(id: ThemeId) {
+    setThemeState(id);
+    applyTheme(id);
+  }
+
+  return { theme, setTheme };
+}
+
+interface ThemeToggleProps {
+  theme: ThemeId;
+  setTheme: (id: ThemeId) => void;
+}
+
+export function ThemeToggle({ theme, setTheme }: ThemeToggleProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="p-1.5 rounded-md transition-colors hover:opacity-80"
+        style={{ color: 'var(--text-secondary)', background: 'transparent' }}
+        title="Change theme"
+        aria-label="Change theme"
+      >
+        <Palette className="w-4 h-4" />
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 z-50 rounded-lg overflow-hidden"
+          style={{
+            background: 'var(--bg-secondary)',
+            border: '1px solid var(--border)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+            minWidth: '180px',
+          }}
+        >
+          <div
+            className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wider"
+            style={{ color: 'var(--text-secondary)', borderBottom: '1px solid var(--border)' }}
+          >
+            Theme
+          </div>
+          {THEMES.map((t) => {
+            const active = theme === t.id;
+            return (
+              <button
+                key={t.id}
+                onClick={() => { setTheme(t.id); setOpen(false); }}
+                className="w-full flex items-center gap-2.5 px-3 py-2 text-xs text-left transition-colors"
+                style={{
+                  color: active ? 'var(--text-primary)' : 'var(--text-secondary)',
+                  background: active ? 'var(--bg-tertiary)' : 'transparent',
+                }}
+              >
+                {/* Swatch */}
+                <span
+                  className="w-4 h-4 rounded shrink-0"
+                  style={{
+                    background: t.bg,
+                    boxShadow: `inset 0 0 0 3px ${t.accent}44, 0 0 0 1px ${t.accent}88`,
+                  }}
+                />
+                <span className="flex-1">{t.label}</span>
+                {active && <Check className="w-3 h-3 shrink-0" style={{ color: 'var(--accent)' }} />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 
-:root {
+/* ─── Default Dark (OctoAlly default) ─────────────────────────────────────── */
+:root,
+[data-theme="default"] {
   --bg-primary: #0f1117;
   --bg-secondary: #1a1d27;
   --bg-tertiary: #242833;
@@ -12,6 +14,123 @@
   --success: #22c55e;
   --warning: #eab308;
   --error: #ef4444;
+}
+
+/* ─── Cyberpunk ────────────────────────────────────────────────────────────── */
+[data-theme="cyberpunk"] {
+  --bg-primary: #050a0e;
+  --bg-secondary: #0d1a20;
+  --bg-tertiary: #162530;
+  --border: #1e3a45;
+  --text-primary: #e0f7f4;
+  --text-secondary: #7ab8b0;
+  --accent: #00ffcc;
+  --accent-hover: #00ccaa;
+  --success: #39ff14;
+  --warning: #ffcc00;
+  --error: #ff2d55;
+}
+
+/* ─── Nord ─────────────────────────────────────────────────────────────────── */
+[data-theme="nord"] {
+  --bg-primary: #2e3440;
+  --bg-secondary: #3b4252;
+  --bg-tertiary: #434c5e;
+  --border: #4c566a;
+  --text-primary: #eceff4;
+  --text-secondary: #d8dee9;
+  --accent: #88c0d0;
+  --accent-hover: #81a1c1;
+  --success: #a3be8c;
+  --warning: #ebcb8b;
+  --error: #bf616a;
+}
+
+/* ─── Solarized Dark ───────────────────────────────────────────────────────── */
+[data-theme="solarized"] {
+  --bg-primary: #002b36;
+  --bg-secondary: #073642;
+  --bg-tertiary: #0e4552;
+  --border: #184f5a;
+  --text-primary: #fdf6e3;
+  --text-secondary: #93a1a1;
+  --accent: #2aa198;
+  --accent-hover: #248f88;
+  --success: #859900;
+  --warning: #b58900;
+  --error: #dc322f;
+}
+
+/* ─── Dracula ──────────────────────────────────────────────────────────────── */
+[data-theme="dracula"] {
+  --bg-primary: #282a36;
+  --bg-secondary: #343746;
+  --bg-tertiary: #3e4155;
+  --border: #44475a;
+  --text-primary: #f8f8f2;
+  --text-secondary: #6272a4;
+  --accent: #bd93f9;
+  --accent-hover: #a87ef7;
+  --success: #50fa7b;
+  --warning: #f1fa8c;
+  --error: #ff5555;
+}
+
+/* ─── Monokai Pro ──────────────────────────────────────────────────────────── */
+[data-theme="monokai"] {
+  --bg-primary: #272822;
+  --bg-secondary: #2d2e27;
+  --bg-tertiary: #35362e;
+  --border: #49483e;
+  --text-primary: #f8f8f2;
+  --text-secondary: #75715e;
+  --accent: #a6e22e;
+  --accent-hover: #8fcc22;
+  --success: #a6e22e;
+  --warning: #e6db74;
+  --error: #f92672;
+}
+
+/* ─── Light ────────────────────────────────────────────────────────────────── */
+[data-theme="light"] {
+  --bg-primary: #f7f8fa;
+  --bg-secondary: #eef0f4;
+  --bg-tertiary: #e3e6ed;
+  --border: #d0d5e0;
+  --text-primary: #1a1d27;
+  --text-secondary: #5a6278;
+  --accent: #0969da;
+  --accent-hover: #0550ae;
+  --success: #1a7f37;
+  --warning: #9a6700;
+  --error: #cf222e;
+}
+
+/* ─── Sunset ───────────────────────────────────────────────────────────────── */
+[data-theme="sunset"] {
+  --bg-primary: #1a1015;
+  --bg-secondary: #251820;
+  --bg-tertiary: #30202c;
+  --border: #3d2835;
+  --text-primary: #f5e6e0;
+  --text-secondary: #a8847c;
+  --accent: #ff9e64;
+  --accent-hover: #e8884d;
+  --success: #a9dc76;
+  --warning: #ffd866;
+  --error: #ff6188;
+}
+
+/* ─── Theme transitions ────────────────────────────────────────────────────── */
+*, *::before, *::after {
+  transition-property: background-color, border-color, color;
+  transition-duration: 200ms;
+  transition-timing-function: ease;
+}
+
+/* Exempt transitions on elements where animation would be jarring */
+.xterm-screen, .xterm-rows, .xterm-viewport, canvas {
+  transition: none !important;
 }
 
 body {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { SkillItem, SystemFeature, Integration } from '../types/skills';
+
 const API_BASE = '/api';
 
 async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
@@ -241,6 +243,18 @@ export const api = {
     fetchJSON<{ ok: boolean }>('/open-terminal', { method: 'POST', body: JSON.stringify({ path }) }),
   versionCheck: () =>
     fetchJSON<{ current: string; latest: string; name: string; url: string; prerelease: boolean; channel: string; updateAvailable: boolean }>('/version-check'),
+  skills: {
+    list: (projectPath?: string) => {
+      const qs = projectPath ? `?project_path=${encodeURIComponent(projectPath)}` : '';
+      return fetchJSON<{ skills: SkillItem[]; categories: string[]; total: number }>(`/skills${qs}`);
+    },
+    systemStatus: () =>
+      fetchJSON<{ features: SystemFeature[]; integrations: Integration[] }>('/system/status'),
+    intents: (projectPath?: string) => {
+      const qs = projectPath ? `?project_path=${encodeURIComponent(projectPath)}` : '';
+      return fetchJSON<{ intents: Array<{ command: string; name: string; category: string; description: string; intents: string[]; weight: number }>; total: number }>(`/skills/intents${qs}`);
+    },
+  },
 };
 
 // Types

--- a/dashboard/src/lib/fuzzy.ts
+++ b/dashboard/src/lib/fuzzy.ts
@@ -1,0 +1,314 @@
+import Fuse from 'fuse.js';
+import type { SkillItem } from '../types/skills';
+
+// ── Synonym map ───────────────────────────────────────────────────
+// Maps common prompt words → skill-relevant keywords so "fix bug"
+// finds /systematic-debugging even though "fix" isn't in the name.
+const SYNONYMS: Record<string, string[]> = {
+  debug:       ['debugging', 'troubleshoot', 'fix', 'error', 'bug', 'issue', 'trace', 'diagnose'],
+  fix:         ['debug', 'repair', 'patch', 'resolve', 'bug', 'error', 'troubleshoot'],
+  test:        ['testing', 'spec', 'unit', 'integration', 'e2e', 'assert', 'verify', 'check'],
+  commit:      ['git', 'save', 'push', 'stage', 'changes', 'version'],
+  review:      ['pr', 'pull-request', 'code-review', 'feedback', 'inspect'],
+  deploy:      ['release', 'ship', 'publish', 'launch', 'ci', 'cd', 'pipeline'],
+  build:       ['compile', 'bundle', 'package', 'construct', 'assemble'],
+  analyze:     ['analysis', 'inspect', 'examine', 'audit', 'evaluate', 'assess', 'scan'],
+  refactor:    ['restructure', 'cleanup', 'improve', 'reorganize', 'simplify'],
+  document:    ['docs', 'documentation', 'readme', 'explain', 'describe', 'comment'],
+  plan:        ['planning', 'design', 'architect', 'strategy', 'roadmap', 'spec'],
+  search:      ['find', 'lookup', 'query', 'grep', 'locate', 'discover'],
+  create:      ['new', 'add', 'generate', 'scaffold', 'init', 'make', 'start'],
+  delete:      ['remove', 'drop', 'clean', 'purge', 'destroy'],
+  update:      ['upgrade', 'modify', 'change', 'edit', 'patch', 'bump'],
+  security:    ['vulnerability', 'audit', 'secure', 'auth', 'permission', 'access'],
+  performance: ['optimize', 'speed', 'fast', 'slow', 'benchmark', 'profile', 'perf'],
+  memory:      ['store', 'recall', 'remember', 'save', 'persist', 'cache'],
+  git:         ['branch', 'merge', 'rebase', 'commit', 'push', 'pull', 'stash', 'diff'],
+  workflow:    ['automate', 'automation', 'pipeline', 'process', 'ci', 'cd'],
+  explain:     ['understand', 'what', 'how', 'why', 'describe', 'clarify'],
+  error:       ['bug', 'crash', 'fail', 'broken', 'wrong', 'issue', 'exception'],
+  brainstorm:  ['idea', 'ideate', 'think', 'explore', 'creative', 'options'],
+  implement:   ['code', 'write', 'develop', 'build', 'create', 'program'],
+  estimate:    ['time', 'effort', 'complexity', 'scope', 'size', 'cost'],
+  hook:        ['hooks', 'event', 'trigger', 'callback', 'lifecycle'],
+  session:     ['save', 'restore', 'state', 'context', 'history'],
+  index:       ['codebase', 'map', 'structure', 'overview', 'navigate'],
+  research:    ['investigate', 'explore', 'study', 'learn', 'survey', 'deep-dive'],
+};
+
+/**
+ * Build expanded keywords string for a skill by matching its text
+ * against the synonym map. This runs once at index time.
+ */
+function expandKeywords(skill: SkillItem): string {
+  const text = [skill.id, skill.name, skill.category, skill.description || '']
+    .join(' ')
+    .toLowerCase();
+  const extra: Set<string> = new Set();
+
+  for (const [trigger, synonyms] of Object.entries(SYNONYMS)) {
+    // If the skill text contains a trigger word, add all its synonyms
+    if (text.includes(trigger)) {
+      for (const s of synonyms) extra.add(s);
+    }
+    // If a synonym appears in the skill text, add the trigger and siblings
+    for (const s of synonyms) {
+      if (text.includes(s)) {
+        extra.add(trigger);
+        for (const sib of synonyms) extra.add(sib);
+        break;
+      }
+    }
+  }
+
+  return Array.from(extra).join(' ');
+}
+
+// ── Fuse index (lazy singleton) ───────────────────────────────────
+interface IndexedSkill extends SkillItem {
+  keywords: string;
+}
+
+let cachedFuseSlash: Fuse<IndexedSkill> | null = null;
+let cachedFuseContext: Fuse<IndexedSkill> | null = null;
+let cachedSkillsRef: SkillItem[] | null = null;
+let indexedSkills: IndexedSkill[] = [];
+
+function ensureIndex(skills: SkillItem[]) {
+  if (cachedSkillsRef === skills) return;
+  cachedSkillsRef = skills;
+
+  indexedSkills = skills.map(s => ({
+    ...s,
+    keywords: expandKeywords(s),
+  }));
+
+  // Slash mode: search name and id with tight threshold
+  cachedFuseSlash = new Fuse(indexedSkills, {
+    keys: [
+      { name: 'id', weight: 0.5 },
+      { name: 'name', weight: 0.3 },
+      { name: 'command', weight: 0.2 },
+    ],
+    includeScore: true,
+    threshold: 0.35,
+    ignoreLocation: true,
+    minMatchCharLength: 1,
+  });
+
+  // Context mode: search wide with synonym keywords
+  cachedFuseContext = new Fuse(indexedSkills, {
+    keys: [
+      { name: 'name', weight: 0.3 },
+      { name: 'keywords', weight: 0.3 },
+      { name: 'description', weight: 0.25 },
+      { name: 'category', weight: 0.15 },
+    ],
+    includeScore: true,
+    threshold: 0.45,
+    ignoreLocation: true,
+    minMatchCharLength: 2,
+  });
+}
+
+// ── Usage weighting ───────────────────────────────────────────────
+const USAGE_KEY = 'octoally:skill-usage';
+
+interface UsageEntry {
+  count: number;
+  lastUsed: number;
+}
+
+function getUsageData(): Record<string, UsageEntry> {
+  try {
+    return JSON.parse(localStorage.getItem(USAGE_KEY) || '{}');
+  } catch { return {}; }
+}
+
+export function recordSkillUsage(skillId: string) {
+  const data = getUsageData();
+  const entry = data[skillId] || { count: 0, lastUsed: 0 };
+  entry.count++;
+  entry.lastUsed = Date.now();
+  data[skillId] = entry;
+  localStorage.setItem(USAGE_KEY, JSON.stringify(data));
+}
+
+function usageBoost(skillId: string): number {
+  const data = getUsageData();
+  const entry = data[skillId];
+  if (!entry) return 1.0;
+
+  const hoursAgo = (Date.now() - entry.lastUsed) / 3_600_000;
+  const recency = Math.max(1.0, 1.3 * Math.exp(-0.1 * hoursAgo));
+  const frequency = 1.0 + Math.log10(1 + entry.count) * 0.1;
+
+  return recency * frequency;
+}
+
+// ── Intent map types ─────────────────────────────────────────────
+export interface IntentEntry {
+  command: string;
+  name: string;
+  category: string;
+  description: string;
+  intents: string[];
+  weight: number;
+}
+
+// ── Public API ────────────────────────────────────────────────────
+
+export interface ScoredSkill {
+  skill: SkillItem;
+  score: number;
+  reason?: string;
+}
+
+/**
+ * Search skills in slash mode (input starts with /).
+ * Handles partial words and typos via fuse.js.
+ */
+export function searchSlash(skills: SkillItem[], query: string, limit: number): ScoredSkill[] {
+  if (!query.trim()) return [];
+  ensureIndex(skills);
+  if (!cachedFuseSlash) return [];
+
+  return cachedFuseSlash.search(query, { limit: limit + 5 })
+    .map(r => ({
+      skill: r.item as SkillItem,
+      score: (1 - (r.score ?? 1)) * usageBoost(r.item.id),
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+/**
+ * Search skills using the server-provided intent map.
+ * Scores each skill by how many of its intent phrases match words in the query.
+ * This replaces fuse.js for context mode — intent phrases are curated to
+ * capture user intent, not just keywords.
+ */
+export function searchIntent(
+  intentMap: IntentEntry[],
+  skills: SkillItem[],
+  query: string,
+  limit: number,
+): ScoredSkill[] {
+  if (query.length < 3) return [];
+
+  const q = query.toLowerCase().trim();
+  const qWords = q.split(/\s+/).filter(w => w.length > 1);
+  if (qWords.length === 0) return [];
+
+  const skillMap = new Map(skills.map(s => [s.command, s]));
+  const scored: Array<{ entry: IntentEntry; score: number; matchedIntent: string }> = [];
+
+  for (const entry of intentMap) {
+    let bestScore = 0;
+    let bestIntent = '';
+
+    for (const intent of entry.intents) {
+      let matchScore = 0;
+
+      // Exact substring match of full query in intent (strong signal)
+      if (intent.includes(q)) {
+        matchScore = 10 + q.length;
+      } else if (q.includes(intent)) {
+        matchScore = 8 + intent.length;
+      } else {
+        // Word overlap scoring
+        const intentWords = intent.split(/\s+/);
+        let wordMatches = 0;
+        let partialMatches = 0;
+        for (const qw of qWords) {
+          for (const iw of intentWords) {
+            if (qw === iw) { wordMatches += 2; break; }
+            if (iw.startsWith(qw) || qw.startsWith(iw)) { partialMatches += 1; break; }
+          }
+        }
+        matchScore = wordMatches + partialMatches * 0.5;
+      }
+
+      if (matchScore > bestScore) {
+        bestScore = matchScore;
+        bestIntent = intent;
+      }
+    }
+
+    if (bestScore > 0) {
+      scored.push({
+        entry,
+        score: bestScore * entry.weight * usageBoost(entry.name),
+        matchedIntent: bestIntent,
+      });
+    }
+  }
+
+  // Sort by score descending, take top N
+  scored.sort((a, b) => b.score - a.score);
+
+  const results: ScoredSkill[] = [];
+  for (const { entry, score, matchedIntent } of scored.slice(0, limit)) {
+    const skill = skillMap.get(entry.command);
+    if (skill) results.push({ skill, score, reason: matchedIntent });
+  }
+  return results;
+}
+
+/**
+ * Search skills in context mode (free-text prompt).
+ * Uses synonym-expanded keywords, handles partial last word.
+ * @deprecated Use searchIntent() when intent map is available
+ */
+export function searchContext(skills: SkillItem[], query: string, limit: number): ScoredSkill[] {
+  if (query.length < 3) return [];
+  ensureIndex(skills);
+  if (!cachedFuseContext) return [];
+
+  const results = cachedFuseContext.search(query, { limit: limit + 5 });
+
+  // Dynamic threshold: only show results close to the best match
+  if (results.length === 0) return [];
+  const bestScore = results[0].score ?? 1;
+  const cutoff = Math.min(bestScore + 0.15, 0.5);
+
+  return results
+    .filter(r => (r.score ?? 1) <= cutoff)
+    .map(r => ({
+      skill: r.item as SkillItem,
+      score: (1 - (r.score ?? 1)) * usageBoost(r.item.id),
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+// ── Legacy exports (keep for CommandPalette/SkillsPanel) ──────────
+
+/**
+ * fzf-style fuzzy scoring: rewards consecutive matches, prefix matches,
+ * and case-sensitive exact hits. Returns -1 for no match.
+ */
+export function fuzzyScore(query: string, target: string): number {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  if (!q) return 0;
+  if (t.startsWith(q)) return 200 + q.length;
+  const subIdx = t.indexOf(q);
+  if (subIdx >= 0) return 100 + q.length - subIdx;
+
+  let score = 0;
+  let qi = 0;
+  let consecutive = 0;
+  let prevMatch = false;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      qi++;
+      consecutive = prevMatch ? consecutive + 1 : 1;
+      score += consecutive * 2 + (ti === 0 ? 5 : 0);
+      prevMatch = true;
+    } else {
+      prevMatch = false;
+    }
+  }
+  return qi === q.length ? score : -1;
+}

--- a/dashboard/src/lib/plugins.ts
+++ b/dashboard/src/lib/plugins.ts
@@ -1,0 +1,22 @@
+export interface PluginPanel {
+  id: string;
+  title: string;
+  path: string;
+}
+
+export interface PluginManifest {
+  name: string;
+  displayName: string;
+  icon?: string;
+  panels: PluginPanel[];
+}
+
+export async function loadPluginManifests(): Promise<PluginManifest[]> {
+  try {
+    const resp = await fetch('/api/plugins/manifests');
+    if (!resp.ok) return [];
+    return await resp.json();
+  } catch {
+    return [];
+  }
+}

--- a/dashboard/src/types/skills.ts
+++ b/dashboard/src/types/skills.ts
@@ -1,0 +1,26 @@
+export interface SkillItem {
+  id: string;
+  name: string;
+  category: string;
+  command: string;
+  scope: 'global' | 'project';
+  description?: string;
+}
+
+export interface SystemFeature {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  status: 'ok' | 'error' | 'degraded' | 'unknown';
+  lastChecked?: number;
+  details?: Record<string, string>;
+}
+
+export interface Integration {
+  id: string;
+  name: string;
+  connected: boolean;
+  status: 'ok' | 'error' | 'degraded' | 'unknown';
+  details?: Record<string, string>;
+}

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -80,12 +80,27 @@ export function initDb(): void {
       value TEXT NOT NULL
     );
 
+    -- Conversation transcripts for replay
+    CREATE TABLE IF NOT EXISTS transcripts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      role TEXT NOT NULL,       -- 'user', 'assistant', 'system', 'tool_use', 'tool_result'
+      content TEXT,
+      tool_name TEXT,
+      tokens_in INTEGER DEFAULT 0,
+      tokens_out INTEGER DEFAULT 0,
+      cost_usd REAL DEFAULT 0,
+      timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     -- Indexes
     CREATE INDEX IF NOT EXISTS idx_pty_output_session_seq ON pty_output(session_id, seq);
     CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
     CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
     CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
     CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+    CREATE INDEX IF NOT EXISTS idx_transcripts_session_seq ON transcripts(session_id, seq);
   `);
 
   // Migrations — idempotent column additions
@@ -102,6 +117,8 @@ export function initDb(): void {
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_events_project ON events(project_id)'); } catch {}
   // Codex support: track which CLI (claude or codex) launched the session
   try { db.exec("ALTER TABLE sessions ADD COLUMN cli_type TEXT DEFAULT 'claude'"); } catch {}
+
+  try { db.exec('ALTER TABLE sessions ADD COLUMN session_state TEXT'); } catch {}
 
   // Note: orphaned process cleanup is handled by cleanupStaleRunningSessions()
   // which is called after initDb() in index.ts — it kills processes AND marks DB records.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,10 @@ import { gitRoutes } from './routes/git.js';
 import { agentRoutes } from './routes/agent.js';
 import { settingsRoutes } from './routes/settings.js';
 import { hooksRoutes } from './routes/hooks.js';
+import { skillsRoutes } from './routes/skills.js';
+import { skillSuggestRoutes } from './routes/skill-suggest.js';
+import { magicDocsRoutes } from './routes/magic-docs.js';
+import { permissionsRoutes } from './routes/permissions.js';
 import { appRouter } from './trpc/router.js';
 import {
   fastifyTRPCPlugin,
@@ -33,7 +37,7 @@ import {
 import type { AppRouter } from './trpc/router.js';
 import { killAllSessions, cleanupStaleRunningSessions, autoReconnectDetachedSessions, getReconnectStatus, startPendingSessionWatchdog } from './services/session-manager.js';
 import { config } from './config.js';
-import { appendFileSync, writeFileSync, readdirSync, existsSync, readFileSync, rmSync } from 'fs';
+import { appendFileSync, writeFileSync, readdirSync, existsSync, readFileSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 const tlog = (s: string) => { try { appendFileSync('/tmp/octoally-timing.log', `[${new Date().toISOString()}] ${s}\n`); } catch {} };
@@ -50,6 +54,34 @@ setInterval(() => {
     tlog(`[LAG] Event loop blocked for ${lag}ms`);
   }
 }, 50).unref();
+
+// --- Plugin loader: scans ~/.octoally/plugins/*/index.js ---
+async function loadPlugins(app: import('fastify').FastifyInstance) {
+  const pluginsDir = join(homedir(), '.octoally', 'plugins');
+  if (!existsSync(pluginsDir)) { mkdirSync(pluginsDir, { recursive: true }); return; }
+  const manifests: any[] = [];
+  for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const pluginEntry = join(pluginsDir, entry.name, 'index.js');
+    const manifestPath = join(pluginsDir, entry.name, 'manifest.json');
+    // Collect manifest if present
+    if (existsSync(manifestPath)) {
+      try { manifests.push(JSON.parse(readFileSync(manifestPath, 'utf-8'))); } catch {}
+    }
+    if (!existsSync(pluginEntry)) continue;
+    try {
+      const mod = await import(pluginEntry);
+      if (typeof mod.default === 'function') {
+        await app.register(mod.default, { prefix: `/api/plugins/${entry.name}` });
+        console.log(`  [plugin] Loaded: ${entry.name}`);
+      }
+    } catch (err: any) {
+      console.error(`  [plugin] Failed to load ${entry.name}: ${err.message}`);
+    }
+  }
+  // Serve collected manifests
+  app.get('/api/plugins/manifests', async () => manifests);
+}
 
 async function start() {
   const app = Fastify({
@@ -259,6 +291,14 @@ async function start() {
         return;
       }
 
+      // Plugin routes are served inside an authenticated dashboard iframe —
+      // the user already passed auth to reach the dashboard.  Plugin
+      // endpoints expose read-only telemetry/search, so exempting them
+      // avoids the need to inject Bearer tokens into panel HTML.
+      if (req.url.startsWith('/api/plugins/')) {
+        return;
+      }
+
       // WebSocket upgrade: check token in query param ?token=
       const isUpgrade = req.headers.upgrade?.toLowerCase() === 'websocket';
       if (isUpgrade) {
@@ -297,6 +337,11 @@ async function start() {
   await app.register(agentRoutes, { prefix: '/api' });
   await app.register(settingsRoutes, { prefix: '/api' });
   await app.register(hooksRoutes, { prefix: '/api' });
+  await app.register(skillsRoutes, { prefix: '/api' });
+  await app.register(skillSuggestRoutes, { prefix: '/api' });
+  await app.register(magicDocsRoutes, { prefix: '/api' });
+  await app.register(permissionsRoutes, { prefix: '/api' });
+  await loadPlugins(app);
 
   // tRPC
   await app.register(fastifyTRPCPlugin, {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,6 +24,7 @@ import { fileRoutes } from './routes/files.js';
 import { gitRoutes } from './routes/git.js';
 import { agentRoutes } from './routes/agent.js';
 import { settingsRoutes } from './routes/settings.js';
+import { hooksRoutes } from './routes/hooks.js';
 import { appRouter } from './trpc/router.js';
 import {
   fastifyTRPCPlugin,
@@ -250,6 +251,40 @@ async function start() {
   });
   await app.register(fastifyWebsocket);
 
+  // --- Authentication: Bearer token check on all routes ---
+  if (config.authToken) {
+    app.addHook('onRequest', async (req, reply) => {
+      // Health check is always public
+      if (req.url === '/api/health' || req.url.startsWith('/api/health?')) {
+        return;
+      }
+
+      // WebSocket upgrade: check token in query param ?token=
+      const isUpgrade = req.headers.upgrade?.toLowerCase() === 'websocket';
+      if (isUpgrade) {
+        const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+        const qToken = url.searchParams.get('token');
+        if (qToken !== config.authToken) {
+          return reply.status(401).send({ error: 'unauthorized' });
+        }
+        return;
+      }
+
+      // Non-API routes (static dashboard files) — skip auth
+      if (!req.url.startsWith('/api/') && !req.url.startsWith('/api')) {
+        return;
+      }
+
+      // Check Bearer token in Authorization header
+      const authHeader = req.headers.authorization;
+      if (!authHeader || !authHeader.startsWith('Bearer ') || authHeader.slice(7) !== config.authToken) {
+        return reply.status(401).send({ error: 'unauthorized' });
+      }
+    });
+  } else {
+    console.warn('[SECURITY] WARNING: OCTOALLY_TOKEN is not set — all API endpoints are unauthenticated. Set OCTOALLY_TOKEN env var to enable authentication.');
+  }
+
   // API routes (REST for hooks, will add tRPC later)
   await app.register(eventRoutes, { prefix: '/api' });
   await app.register(sessionRoutes, { prefix: '/api' });
@@ -261,6 +296,7 @@ async function start() {
   await app.register(gitRoutes, { prefix: '/api' });
   await app.register(agentRoutes, { prefix: '/api' });
   await app.register(settingsRoutes, { prefix: '/api' });
+  await app.register(hooksRoutes, { prefix: '/api' });
 
   // tRPC
   await app.register(fastifyTRPCPlugin, {

--- a/server/src/routes/files.ts
+++ b/server/src/routes/files.ts
@@ -2,12 +2,35 @@ import { FastifyPluginAsync } from 'fastify';
 import { readdir, stat, readFile, writeFile } from 'fs/promises';
 import { join, resolve, extname } from 'path';
 import { exec } from 'child_process';
+import { getDb } from '../db/index.js';
 
 interface FileEntry {
   name: string;
   type: 'file' | 'directory';
   size: number;
   extension: string;
+}
+
+/**
+ * Validate that a resolved path is within one of the registered project directories.
+ * Returns true if the path is allowed, false if it's outside all project dirs.
+ */
+function isPathAllowed(resolvedPath: string): boolean {
+  try {
+    const db = getDb();
+    const projects = db.prepare('SELECT path FROM projects').all() as { path: string }[];
+    for (const { path: projectPath } of projects) {
+      const normalizedProject = resolve(projectPath);
+      // Path must be the project dir itself or a descendant
+      if (resolvedPath === normalizedProject || resolvedPath.startsWith(normalizedProject + '/')) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    // If DB is unavailable, deny by default
+    return false;
+  }
 }
 
 export const fileRoutes: FastifyPluginAsync = async (app) => {
@@ -20,6 +43,10 @@ export const fileRoutes: FastifyPluginAsync = async (app) => {
     const showHidden = req.query.showHidden === 'true';
 
     const resolved = resolve(dirPath);
+
+    if (!isPathAllowed(resolved)) {
+      return reply.status(403).send({ error: 'Access denied: path is outside registered project directories' });
+    }
 
     try {
       const entries = await readdir(resolved, { withFileTypes: true });
@@ -68,6 +95,10 @@ export const fileRoutes: FastifyPluginAsync = async (app) => {
 
     const resolved = resolve(filePath);
 
+    if (!isPathAllowed(resolved)) {
+      return reply.status(403).send({ error: 'Access denied: path is outside registered project directories' });
+    }
+
     try {
       const stats = await stat(resolved);
       // Limit to 1MB files
@@ -95,6 +126,10 @@ export const fileRoutes: FastifyPluginAsync = async (app) => {
 
     const resolved = resolve(filePath);
 
+    if (!isPathAllowed(resolved)) {
+      return reply.status(403).send({ error: 'Access denied: path is outside registered project directories' });
+    }
+
     try {
       // Verify file exists (won't create new files)
       await stat(resolved);
@@ -116,6 +151,10 @@ export const fileRoutes: FastifyPluginAsync = async (app) => {
 
     const resolvedA = resolve(pathA);
     const resolvedB = resolve(pathB);
+
+    if (!isPathAllowed(resolvedA) || !isPathAllowed(resolvedB)) {
+      return reply.status(403).send({ error: 'Access denied: path is outside registered project directories' });
+    }
 
     // Verify both files exist
     try { await stat(resolvedA); } catch { return reply.status(404).send({ error: `File not found: ${pathA}` }); }
@@ -156,6 +195,10 @@ export const fileRoutes: FastifyPluginAsync = async (app) => {
     if (!path) return reply.status(400).send({ error: 'path is required' });
 
     const resolved = resolve(path);
+
+    if (!isPathAllowed(resolved)) {
+      return reply.status(403).send({ error: 'Access denied: path is outside registered project directories' });
+    }
 
     return new Promise((resolvePromise) => {
       exec(`code "${resolved}"`, (err) => {

--- a/server/src/routes/hooks.ts
+++ b/server/src/routes/hooks.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join, dirname } from 'path';
 import { config } from '../config.js';
+import { insertEvent } from '../services/event-store.js';
 
 const OCTOALLY_HOOK_MARKER = '# octoally-events-hook';
 const LEGACY_HOOK_MARKER = '# hivecommand-events-hook';
@@ -129,6 +130,75 @@ function uninstallHook(settings: ClaudeSettings): ClaudeSettings {
   return settings;
 }
 
+// ─── Notification Hook Types ──────────────────────────────────
+// 6 core notification hooks for system-wide event observation.
+
+export type NotificationHookType =
+  | 'rate_limit'       // Fired when API rate limit hit (429)
+  | 'budget_warn'      // Fired when budget threshold crossed
+  | 'session_complete' // Fired when a session finishes
+  | 'tool_denied'      // Fired when a tool is denied by permission system
+  | 'error_spike'      // Fired when error rate exceeds threshold
+  | 'model_change';    // Fired when model changes mid-session
+
+export interface NotificationHookRegistration {
+  id: string;
+  type: NotificationHookType;
+  callback_url?: string;    // Optional webhook URL
+  log_to_events: boolean;   // Whether to log to event store
+  enabled: boolean;
+  created_at: string;
+}
+
+export interface NotificationHookPayload {
+  type: NotificationHookType;
+  session_id?: string;
+  detail: Record<string, unknown>;
+  timestamp: string;
+}
+
+// In-memory hook registrations
+const notificationHooks: Map<string, NotificationHookRegistration> = new Map();
+
+const VALID_HOOK_TYPES: NotificationHookType[] = [
+  'rate_limit', 'budget_warn', 'session_complete',
+  'tool_denied', 'error_spike', 'model_change',
+];
+
+/**
+ * Fire a notification hook. Iterates all registered hooks matching the type,
+ * logs to event store if configured, and dispatches webhook if configured.
+ * All webhook failures are non-fatal.
+ */
+export async function fireNotificationHook(payload: NotificationHookPayload): Promise<void> {
+  for (const [, reg] of notificationHooks) {
+    if (reg.type !== payload.type || !reg.enabled) continue;
+
+    // Log to event store
+    if (reg.log_to_events) {
+      insertEvent({
+        session_id: payload.session_id,
+        type: `hook:${payload.type}`,
+        data: payload.detail,
+      });
+    }
+
+    // Fire webhook if configured
+    if (reg.callback_url) {
+      try {
+        await fetch(reg.callback_url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(5000),
+        });
+      } catch {
+        // Webhook failures are non-fatal
+      }
+    }
+  }
+}
+
 export const hooksRoutes: FastifyPluginAsync = async (app) => {
   // Check if the OctoAlly events hook is installed for a project
   app.get<{
@@ -161,5 +231,91 @@ export const hooksRoutes: FastifyPluginAsync = async (app) => {
 
     await saveSettings(projectPath, settings);
     return { ok: true, installed: isHookInstalled(settings) };
+  });
+
+  // ─── Notification Hook API Routes ───────────────────────────
+
+  // List all notification hook registrations
+  app.get('/hooks/notifications', async (_req, reply) => {
+    const hooks = Array.from(notificationHooks.values());
+    return reply.send({ ok: true, hooks });
+  });
+
+  // Register a new notification hook
+  app.post<{
+    Body: { type: NotificationHookType; callback_url?: string; log_to_events?: boolean };
+  }>('/hooks/notifications/register', async (req, reply) => {
+    const { type, callback_url, log_to_events } = req.body || {};
+
+    if (!type || !VALID_HOOK_TYPES.includes(type)) {
+      return reply.status(400).send({
+        ok: false,
+        error: `Invalid hook type. Valid: ${VALID_HOOK_TYPES.join(', ')}`,
+      });
+    }
+
+    const id = `nhook_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const registration: NotificationHookRegistration = {
+      id,
+      type,
+      callback_url,
+      log_to_events: log_to_events !== false,
+      enabled: true,
+      created_at: new Date().toISOString(),
+    };
+
+    notificationHooks.set(id, registration);
+    return reply.send({ ok: true, hook: registration });
+  });
+
+  // Enable/disable a notification hook
+  app.patch<{
+    Params: { id: string };
+    Body: { enabled?: boolean };
+  }>('/hooks/notifications/:id', async (req, reply) => {
+    const reg = notificationHooks.get(req.params.id);
+    if (!reg) {
+      return reply.status(404).send({ ok: false, error: 'Hook not found' });
+    }
+
+    if (typeof req.body?.enabled === 'boolean') {
+      reg.enabled = req.body.enabled;
+    }
+
+    return reply.send({ ok: true, hook: reg });
+  });
+
+  // Delete a notification hook
+  app.delete<{
+    Params: { id: string };
+  }>('/hooks/notifications/:id', async (req, reply) => {
+    if (notificationHooks.delete(req.params.id)) {
+      return reply.send({ ok: true });
+    }
+    return reply.status(404).send({ ok: false, error: 'Hook not found' });
+  });
+
+  // Fire a notification hook manually (for testing)
+  app.post<{
+    Body: { type: NotificationHookType; session_id?: string; detail?: Record<string, unknown> };
+  }>('/hooks/notifications/fire', async (req, reply) => {
+    const { type, session_id, detail = {} } = req.body || {};
+
+    if (!type || !VALID_HOOK_TYPES.includes(type)) {
+      return reply.status(400).send({
+        ok: false,
+        error: `Invalid hook type. Valid: ${VALID_HOOK_TYPES.join(', ')}`,
+      });
+    }
+
+    const payload: NotificationHookPayload = {
+      type,
+      session_id,
+      detail,
+      timestamp: new Date().toISOString(),
+    };
+
+    await fireNotificationHook(payload);
+    return reply.send({ ok: true, fired: type });
   });
 };

--- a/server/src/routes/magic-docs.ts
+++ b/server/src/routes/magic-docs.ts
@@ -1,0 +1,41 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { getSuggestions, getQuickActions } from '../services/magic-docs.js';
+
+export const magicDocsRoutes: FastifyPluginAsync = async (app) => {
+  // GET /api/suggestions?context=<text>&file=<path>&max=<n>
+  // Returns context-aware prompt suggestions.
+  // - context: free-form text (treated as file content for analysis)
+  // - file:    optional file path (used for extension-based hints)
+  // - max:     optional max suggestions to return (default 5)
+  app.get('/suggestions', async (req, reply) => {
+    const q = req.query as Record<string, string>;
+    const context = q.context || '';
+    const filePath = q.file || undefined;
+    const maxSuggestions = Math.max(1, parseInt(q.max, 10) || 5);
+
+    if (!context && !filePath) {
+      return reply.status(400).send({ error: 'Provide at least one of: context, file' });
+    }
+
+    const suggestions = getSuggestions({
+      filePath,
+      fileContent: context || undefined,
+      maxSuggestions,
+    });
+
+    return { suggestions, total: suggestions.length };
+  });
+
+  // GET /api/quick-actions?path=<file_path>
+  // Returns quick action suggestions for the given file path.
+  app.get('/quick-actions', async (req, reply) => {
+    const filePath = (req.query as Record<string, string>).path;
+
+    if (!filePath) {
+      return reply.status(400).send({ error: 'path query parameter is required' });
+    }
+
+    const actions = getQuickActions(filePath);
+    return { actions, total: actions.length };
+  });
+};

--- a/server/src/routes/permissions.ts
+++ b/server/src/routes/permissions.ts
@@ -1,0 +1,84 @@
+import type { FastifyPluginAsync } from 'fastify';
+import {
+  grantPermissions,
+  checkPermission,
+  revokePermissions,
+  getPermissions,
+} from '../services/session-manager.js';
+
+export const permissionsRoutes: FastifyPluginAsync = async (app) => {
+  // POST /api/permissions/grant
+  // Body: { parentId: string, childId: string, permissions?: string[] }
+  // permissions maps to restrictTools — narrows the allowed set for the child.
+  app.post<{
+    Body: { parentId?: string; childId?: string; permissions?: string[] };
+  }>('/permissions/grant', async (req, reply) => {
+    const { parentId, childId, permissions } = req.body || {};
+
+    if (!childId || typeof childId !== 'string') {
+      return reply.status(400).send({ ok: false, error: 'childId is required' });
+    }
+
+    const resolvedParentId = (parentId && typeof parentId === 'string') ? parentId : null;
+
+    const grant = grantPermissions(
+      childId,
+      resolvedParentId,
+      permissions && permissions.length > 0 ? { restrictTools: permissions } : undefined,
+    );
+
+    return reply.send({ ok: true, grant });
+  });
+
+  // GET /api/permissions/check?sessionId=X&tool=Y
+  // Returns { allowed: boolean, reason: string }
+  app.get<{
+    Querystring: { sessionId?: string; tool?: string };
+  }>('/permissions/check', async (req, reply) => {
+    const { sessionId, tool } = req.query;
+
+    if (!sessionId || typeof sessionId !== 'string') {
+      return reply.status(400).send({ ok: false, error: 'sessionId query parameter is required' });
+    }
+    if (!tool || typeof tool !== 'string') {
+      return reply.status(400).send({ ok: false, error: 'tool query parameter is required' });
+    }
+
+    const grant = getPermissions(sessionId);
+    const allowed = checkPermission(sessionId, tool);
+
+    let reason: string;
+    if (!grant) {
+      reason = 'no_grant_root_session';
+    } else if (!allowed) {
+      const isDenied = grant.deniedTools.some(
+        (d) => tool.startsWith(d) || d === tool,
+      );
+      reason = isDenied ? 'explicitly_denied' : 'not_in_allowlist';
+    } else {
+      reason = 'allowed';
+    }
+
+    return reply.send({ allowed, reason });
+  });
+
+  // POST /api/permissions/revoke
+  // Body: { parentId?: string, childId: string }
+  // Revokes the permission grant for childId.
+  app.post<{
+    Body: { parentId?: string; childId?: string };
+  }>('/permissions/revoke', async (req, reply) => {
+    const { childId } = req.body || {};
+
+    if (!childId || typeof childId !== 'string') {
+      return reply.status(400).send({ ok: false, error: 'childId is required' });
+    }
+
+    const existed = revokePermissions(childId);
+    if (!existed) {
+      return reply.status(404).send({ ok: false, error: 'No permission grant found for childId' });
+    }
+
+    return reply.send({ ok: true });
+  });
+};

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -9,6 +9,7 @@ import * as sessionManager from '../services/session-manager.js';
 import { RESIZE_MARKER, registerPendingSpawn, getSessionTmuxServer } from '../services/session-manager.js';
 import { getTracker } from '../services/session-state.js';
 import { getDb } from '../db/index.js';
+import { getTranscript, getEvents } from '../services/event-store.js';
 
 export const sessionRoutes: FastifyPluginAsync = async (app) => {
   // List sessions
@@ -127,6 +128,49 @@ export const sessionRoutes: FastifyPluginAsync = async (app) => {
       } catch { /* ignore */ }
     }
     return { ok: true };
+  });
+
+  // Session replay — ordered transcript with timing
+  app.get<{
+    Params: { id: string };
+    Querystring: { limit?: string; offset?: string };
+  }>('/sessions/:id/replay', async (req, reply) => {
+    try {
+      const { id } = req.params;
+      const limit = parseInt(req.query.limit as string) || 1000;
+      const offset = parseInt(req.query.offset as string) || 0;
+
+      const transcript = getTranscript(id, { limit, offset });
+
+      if (transcript.length === 0) {
+        // Fall back to events if no transcript entries
+        const events = getEvents({ session_id: id, limit });
+        return {
+          ok: true,
+          session_id: id,
+          type: 'events_fallback',
+          entries: events.map((e, i) => ({
+            seq: i + 1,
+            role: e.type === 'tool_use' ? 'tool_use' : e.type === 'tool_result' ? 'tool_result' : 'system',
+            content: e.data,
+            tool_name: e.tool_name,
+            timestamp: e.timestamp,
+          })),
+          total: events.length,
+        };
+      }
+
+      return {
+        ok: true,
+        session_id: id,
+        type: 'transcript',
+        entries: transcript,
+        total: transcript.length,
+      };
+    } catch (err) {
+      reply.status(500);
+      return { ok: false, error: String(err) };
+    }
   });
 
   // Concise context summary for cross-session awareness (low token cost)

--- a/server/src/routes/skill-suggest.ts
+++ b/server/src/routes/skill-suggest.ts
@@ -1,0 +1,159 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { join, resolve } from 'path';
+import { homedir } from 'os';
+import { existsSync, statSync } from 'fs';
+import { scanSkillsDir, type SkillItem } from './skills.js';
+
+// ── Intent map ───────────────────────────────────────────────────
+// Pre-computed mapping from user intent phrases to skill commands.
+// This gives AI-quality suggestions without per-request LLM calls.
+// The map is built from skill metadata + curated intent keywords.
+
+interface IntentEntry {
+  command: string;
+  name: string;
+  category: string;
+  description: string;
+  // Intent keywords: things a user might type when they need this skill
+  intents: string[];
+  // Weight for ranking (higher = more likely to suggest)
+  weight: number;
+}
+
+/**
+ * Build a rich intent map from skills. Each skill gets intent keywords
+ * derived from its metadata plus curated semantic expansions.
+ */
+function buildIntentMap(skills: SkillItem[]): IntentEntry[] {
+  // Curated intent expansions per skill ID pattern
+  const INTENT_EXPANSIONS: Record<string, string[]> = {
+    // General skills
+    'commit': ['save changes', 'git commit', 'push code', 'stage', 'done coding', 'finished', 'save work'],
+    'create-pr': ['pull request', 'open pr', 'submit changes', 'merge request', 'code review ready'],
+    'pr-review': ['review code', 'check pr', 'review pull request', 'code feedback', 'approve changes'],
+    'deep-analyze': ['analyze', 'investigate', 'multiple angles', 'board meeting', 'multi perspective', 'evaluate options'],
+    'fix-github-issue': ['github issue', 'fix issue', 'close issue', 'bug report', 'issue tracker'],
+    'index': ['codebase overview', 'project structure', 'file map', 'what files', 'navigate code'],
+    'codebase-map': ['architecture', 'dependencies', 'data flow', 'how does it work', 'system diagram'],
+    'reflect': ['what went well', 'session review', 'retrospective', 'what did we do'],
+    'save-session': ['save progress', 'handoff', 'continue later', 'session notes', 'bookmark'],
+    'release': ['version bump', 'changelog', 'ship release', 'new version', 'publish'],
+    'create-hook': ['lifecycle hook', 'event handler', 'automation trigger', 'on save', 'on commit'],
+    'todo': ['task list', 'what to do', 'remaining work', 'checklist', 'plan tasks'],
+    'act': ['tdd', 'red green refactor', 'test driven', 'write tests first'],
+    'ruflo-search': ['search memory', 'find in memory', 'recall', 'what did we decide', 'previous work'],
+    'evaluate-repository': ['audit repo', 'security scan', 'code quality', 'repo health'],
+
+    // SC skills
+    'sc:troubleshoot': ['fix bug', 'debug', 'broken', 'not working', 'error', 'crash', 'fails', 'wrong output',
+      'investigate issue', 'diagnose', 'trace error', 'stack trace', 'exception', 'unexpected behavior'],
+    'sc:implement': ['build feature', 'write code', 'implement', 'create function', 'add functionality',
+      'coding task', 'develop', 'program', 'new feature', 'add support for'],
+    'sc:analyze': ['code review', 'quality check', 'audit code', 'assess', 'evaluate code',
+      'technical debt', 'code smell', 'complexity', 'maintainability'],
+    'sc:test': ['run tests', 'write tests', 'test coverage', 'unit test', 'integration test',
+      'verify works', 'check tests', 'testing', 'spec', 'assertion'],
+    'sc:build': ['compile', 'build project', 'package', 'bundle', 'webpack', 'vite build',
+      'npm build', 'build error', 'compilation'],
+    'sc:design': ['architecture design', 'system design', 'api design', 'component design',
+      'plan architecture', 'database schema', 'interface design', 'data model'],
+    'sc:explain': ['explain code', 'what does this do', 'how does this work', 'understand',
+      'walk through', 'clarify', 'documentation', 'teach me'],
+    'sc:research': ['look up', 'find information', 'research topic', 'best practices',
+      'how to', 'learn about', 'explore options', 'compare approaches', 'state of the art'],
+    'sc:brainstorm': ['brainstorm', 'ideate', 'explore ideas', 'creative solutions',
+      'what should we', 'options', 'approach', 'strategy', 'think through'],
+    'sc:improve': ['refactor', 'clean up', 'optimize', 'make better', 'improve performance',
+      'simplify', 'reduce complexity', 'modernize', 'upgrade code'],
+    'sc:cleanup': ['remove dead code', 'clean project', 'organize files', 'delete unused',
+      'reduce bloat', 'tidy up', 'housekeeping'],
+    'sc:document': ['write docs', 'add documentation', 'api docs', 'jsdoc', 'readme',
+      'explain api', 'document function', 'add comments'],
+    'sc:git': ['git status', 'branch', 'merge', 'rebase', 'stash', 'diff', 'git log',
+      'undo commit', 'cherry pick', 'resolve conflict'],
+    'sc:estimate': ['how long', 'estimate effort', 'complexity estimate', 'time estimate',
+      'story points', 'scope assessment', 'feasibility'],
+    'sc:workflow': ['prd', 'product spec', 'feature spec', 'implementation plan',
+      'workflow from spec', 'requirements to code'],
+    'sc:recommend': ['which command', 'what skill', 'suggest tool', 'help me choose',
+      'best approach', 'which one should i use'],
+    'sc:spawn': ['multi agent', 'parallel tasks', 'delegate', 'break down task',
+      'complex task', 'orchestrate', 'coordinate agents'],
+    'sc:task': ['complex task', 'multi step', 'workflow execution', 'end to end'],
+
+    // Seed skills
+    'seed:seed': ['new project', 'start project', 'create app', 'build something new',
+      'idea', 'from scratch', 'greenfield'],
+    'seed:tasks:ideate': ['brainstorm project', 'explore idea', 'project concept'],
+    'seed:tasks:graduate': ['graduate project', 'make standalone', 'separate repo'],
+    'seed:tasks:launch': ['launch project', 'deploy', 'go live', 'ship it'],
+  };
+
+  const EXCLUDE_PREFIXES = ['seed:data:', 'seed:templates:', 'seed:checklists:'];
+
+  return skills
+    .filter(s => !EXCLUDE_PREFIXES.some(p => s.id.startsWith(p)))
+    .map(s => {
+      // Base intents from skill metadata
+      const baseIntents = [
+        s.name,
+        s.id,
+        s.category,
+        ...(s.description || '').toLowerCase().split(/\s+/).filter(w => w.length > 3),
+      ];
+
+      // Curated expansions
+      const curated = INTENT_EXPANSIONS[s.id] || INTENT_EXPANSIONS[s.name] || [];
+
+      return {
+        command: s.command,
+        name: s.name,
+        category: s.category,
+        description: (s.description || s.name).slice(0, 80),
+        intents: [...new Set([...baseIntents, ...curated])].map(i => i.toLowerCase()),
+        weight: curated.length > 0 ? 1.2 : 1.0, // Boost curated skills
+      };
+    });
+}
+
+// ── Skill scanning helper ────────────────────────────────────────
+function getAllSkills(projectPath?: string): SkillItem[] {
+  const userDir = join(homedir(), '.claude', 'commands');
+  const skills = scanSkillsDir(userDir, 'global');
+
+  if (projectPath) {
+    const resolved = resolve(projectPath);
+    if (projectPath === resolved && existsSync(resolved) && statSync(resolved).isDirectory()) {
+      const projectDir = join(resolved, '.claude', 'commands');
+      skills.push(...scanSkillsDir(projectDir, 'project'));
+    }
+  }
+
+  return skills;
+}
+
+// ── Cache ────────────────────────────────────────────────────────
+let cachedIntentMap: IntentEntry[] | null = null;
+let cachedHash = '';
+
+function ensureIntentMap(projectPath?: string): IntentEntry[] {
+  const skills = getAllSkills(projectPath);
+  const hash = skills.map(s => s.id).sort().join(',');
+
+  if (hash !== cachedHash || !cachedIntentMap) {
+    cachedIntentMap = buildIntentMap(skills);
+    cachedHash = hash;
+  }
+
+  return cachedIntentMap;
+}
+
+// ── Route ────────────────────────────────────────────────────────
+export const skillSuggestRoutes: FastifyPluginAsync = async (app) => {
+  // GET /skills/intents — returns the full intent map for client-side matching
+  app.get('/skills/intents', async (req) => {
+    const projectPath = (req.query as Record<string, string>).project_path;
+    const intentMap = ensureIntentMap(projectPath);
+    return { intents: intentMap, total: intentMap.length };
+  });
+};

--- a/server/src/routes/skills.ts
+++ b/server/src/routes/skills.ts
@@ -1,0 +1,152 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { join, resolve } from 'path';
+import { homedir } from 'os';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+
+export interface SkillItem {
+  id: string;
+  name: string;
+  category: string;
+  command: string;
+  scope: 'global' | 'project';
+  description?: string;
+}
+
+export function scanSkillsDir(dir: string, scope: 'global' | 'project'): SkillItem[] {
+  const skills: SkillItem[] = [];
+  if (!existsSync(dir)) return skills;
+
+  function walk(currentDir: string, categoryPath: string) {
+    for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        // Skip hidden directories
+        if (entry.name.startsWith('.')) continue;
+        const nested = categoryPath === 'root' ? entry.name : `${categoryPath}:${entry.name}`;
+        walk(join(currentDir, entry.name), nested);
+      } else if (entry.name.endsWith('.md')) {
+        const name = entry.name.replace(/\.md$/, '');
+        const category = categoryPath;
+        const id = category === 'root' ? name : `${category}:${name}`;
+        // Read first non-empty, non-frontmatter line as description
+        let description: string | undefined;
+        try {
+          const content = readFileSync(join(currentDir, entry.name), 'utf-8');
+          const lines = content.split('\n');
+          let inFrontmatter = false;
+          for (const line of lines) {
+            if (line.trim() === '---') { inFrontmatter = !inFrontmatter; continue; }
+            if (inFrontmatter) continue;
+            const trimmed = line.trim();
+            if (trimmed && !trimmed.startsWith('#')) {
+              description = trimmed.slice(0, 120);
+              break;
+            }
+          }
+        } catch {}
+        skills.push({
+          id,
+          name,
+          category: category === 'root' ? 'general' : category,
+          command: `/${id}`,
+          scope,
+          description,
+        });
+      }
+    }
+  }
+
+  walk(dir, 'root');
+  return skills;
+}
+
+export const skillsRoutes: FastifyPluginAsync = async (app) => {
+  // GET /skills — returns all available skills
+  app.get('/skills', async (req) => {
+    const projectPath = (req.query as Record<string, string>).project_path;
+
+    // User-level skills
+    const userDir = join(homedir(), '.claude', 'commands');
+    const skills = scanSkillsDir(userDir, 'global');
+
+    // Project-level skills (if project_path provided, with path traversal protection)
+    if (projectPath) {
+      const resolved = resolve(projectPath);
+      if (projectPath === resolved && existsSync(resolved) && statSync(resolved).isDirectory()) {
+        const projectDir = join(resolved, '.claude', 'commands');
+        skills.push(...scanSkillsDir(projectDir, 'project'));
+      }
+    }
+
+    // Sort: project skills first, then alphabetically by category and name
+    skills.sort((a, b) => {
+      if (a.scope !== b.scope) return a.scope === 'project' ? -1 : 1;
+      if (a.category !== b.category) return a.category.localeCompare(b.category);
+      return a.name.localeCompare(b.name);
+    });
+
+    // Derive categories
+    const categories = [...new Set(skills.map(s => s.category))].sort();
+
+    return { skills, categories, total: skills.length };
+  });
+
+  // GET /system/status — returns system features and integrations
+  app.get('/system/status', async () => {
+    const features = [];
+    const integrations = [];
+
+    const nexusRoot = process.env.ALETHEIA_NEXUS_PATH || '/home/hemang/ALETHEIA-NEXUS';
+
+    // Check RAG status
+    const ragStore = `${nexusRoot}/config/rag_store`;
+    features.push({
+      id: 'local-rag',
+      name: 'Local RAG',
+      description: 'LanceDB + Ollama embeddings (849 chunks)',
+      enabled: existsSync(ragStore),
+      status: existsSync(ragStore) ? 'ok' : 'error',
+      details: { store: ragStore },
+    });
+
+    // Check SmartRouter
+    const routerDb = `${nexusRoot}/config/router_telemetry.db`;
+    features.push({
+      id: 'smart-router',
+      name: 'Smart Router',
+      description: 'Dual-model routing with telemetry',
+      enabled: true,
+      status: existsSync(routerDb) ? 'ok' : 'degraded',
+      details: { telemetry: routerDb },
+    });
+
+    // Check Ollama
+    integrations.push({
+      id: 'ollama',
+      name: 'Ollama',
+      connected: false, // Will be checked client-side or via health endpoint
+      status: 'unknown' as const,
+      details: { url: 'http://127.0.0.1:11434' },
+    });
+
+    // Check Gemini CLI
+    const geminiDispatch = `${nexusRoot}/scripts/gemini_dispatch.sh`;
+    integrations.push({
+      id: 'gemini-cli',
+      name: 'Gemini CLI',
+      connected: existsSync(geminiDispatch),
+      status: existsSync(geminiDispatch) ? 'ok' : 'error',
+      details: { script: geminiDispatch },
+    });
+
+    // Check ALETHEIA-NEXUS
+    integrations.push({
+      id: 'aletheia-nexus',
+      name: 'ALETHEIA-NEXUS',
+      connected: existsSync(join(nexusRoot, '.venv', 'bin', 'python')),
+      status: existsSync(join(nexusRoot, '.venv', 'bin', 'python')) ? 'ok' : 'error',
+      details: { path: nexusRoot },
+    });
+
+    return { features, integrations };
+  });
+};

--- a/server/src/routes/skills.ts
+++ b/server/src/routes/skills.ts
@@ -119,13 +119,25 @@ export const skillsRoutes: FastifyPluginAsync = async (app) => {
       details: { telemetry: routerDb },
     });
 
-    // Check Ollama
+    // Check Ollama — TCP probe GPU tunnel (11435) then CPU (11434)
+    const { createConnection } = await import('net');
+    const tcpProbe = (port: number): Promise<boolean> => new Promise(resolve => {
+      const sock = createConnection({ host: '127.0.0.1', port, timeout: 400 }, () => { sock.destroy(); resolve(true); });
+      sock.on('error', () => resolve(false));
+      sock.on('timeout', () => { sock.destroy(); resolve(false); });
+    });
+    let ollamaStatus: { connected: boolean; gpu: boolean; url: string } = { connected: false, gpu: false, url: '' };
+    if (await tcpProbe(11435)) {
+      ollamaStatus = { connected: true, gpu: true, url: 'http://127.0.0.1:11435' };
+    } else if (await tcpProbe(11434)) {
+      ollamaStatus = { connected: true, gpu: false, url: 'http://127.0.0.1:11434' };
+    }
     integrations.push({
       id: 'ollama',
       name: 'Ollama',
-      connected: false, // Will be checked client-side or via health endpoint
-      status: 'unknown' as const,
-      details: { url: 'http://127.0.0.1:11434' },
+      connected: ollamaStatus.connected,
+      status: ollamaStatus.connected ? 'ok' : 'error',
+      details: { url: ollamaStatus.url || 'http://127.0.0.1:11434', gpu: ollamaStatus.gpu },
     });
 
     // Check Gemini CLI

--- a/server/src/routes/skills.ts
+++ b/server/src/routes/skills.ts
@@ -95,7 +95,7 @@ export const skillsRoutes: FastifyPluginAsync = async (app) => {
     const features = [];
     const integrations = [];
 
-    const nexusRoot = process.env.ALETHEIA_NEXUS_PATH || '/home/hemang/ALETHEIA-NEXUS';
+    const nexusRoot = process.env.ALETHEIA_NEXUS_PATH || join(homedir(), 'ALETHEIA-NEXUS');
 
     // Check RAG status
     const ragStore = `${nexusRoot}/config/rag_store`;

--- a/server/src/services/event-store.ts
+++ b/server/src/services/event-store.ts
@@ -89,3 +89,76 @@ export function getEvents(options?: {
 
   return db.prepare(`SELECT * FROM events ${where} ORDER BY id DESC LIMIT ?`).all(...params, limit) as Event[];
 }
+
+// ─── Transcript Management ──────────────────────────────────────
+
+export interface TranscriptEntry {
+  id: number;
+  session_id: string;
+  seq: number;
+  role: string;
+  content: string | null;
+  tool_name: string | null;
+  tokens_in: number;
+  tokens_out: number;
+  cost_usd: number;
+  timestamp: string;
+}
+
+export function appendTranscript(entry: {
+  session_id: string;
+  seq: number;
+  role: string;
+  content?: string;
+  tool_name?: string;
+  tokens_in?: number;
+  tokens_out?: number;
+  cost_usd?: number;
+}): TranscriptEntry {
+  const db = getDb();
+  const stmt = db.prepare(`
+    INSERT INTO transcripts (session_id, seq, role, content, tool_name, tokens_in, tokens_out, cost_usd)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const result = stmt.run(
+    entry.session_id,
+    entry.seq,
+    entry.role,
+    entry.content || null,
+    entry.tool_name || null,
+    entry.tokens_in || 0,
+    entry.tokens_out || 0,
+    entry.cost_usd || 0
+  );
+  return db.prepare('SELECT * FROM transcripts WHERE id = ?').get(result.lastInsertRowid) as TranscriptEntry;
+}
+
+export function getTranscript(session_id: string, options?: { limit?: number; offset?: number }): TranscriptEntry[] {
+  const db = getDb();
+  const limit = options?.limit || 1000;
+  const offset = options?.offset || 0;
+  return db.prepare(
+    'SELECT * FROM transcripts WHERE session_id = ? ORDER BY seq ASC LIMIT ? OFFSET ?'
+  ).all(session_id, limit, offset) as TranscriptEntry[];
+}
+
+export function compactTranscript(session_id: string, keepLast: number = 50): number {
+  const db = getDb();
+  const maxSeq = db.prepare(
+    'SELECT MAX(seq) as max_seq FROM transcripts WHERE session_id = ?'
+  ).get(session_id) as { max_seq: number | null };
+
+  if (!maxSeq?.max_seq || maxSeq.max_seq <= keepLast) return 0;
+
+  const cutoff = maxSeq.max_seq - keepLast;
+  const result = db.prepare(
+    'DELETE FROM transcripts WHERE session_id = ? AND seq <= ?'
+  ).run(session_id, cutoff);
+  return result.changes;
+}
+
+export function flushTranscript(session_id: string): number {
+  const db = getDb();
+  const result = db.prepare('DELETE FROM transcripts WHERE session_id = ?').run(session_id);
+  return result.changes;
+}

--- a/server/src/services/flush-gate.ts
+++ b/server/src/services/flush-gate.ts
@@ -1,0 +1,105 @@
+/**
+ * flush-gate.ts — Buffer WebSocket messages during burst, flush on calm.
+ *
+ * When output arrives faster than the client can consume it,
+ * the flush gate batches messages and sends them in chunks.
+ * This prevents the WebSocket from being overwhelmed during
+ * high-output operations (like large test suites or builds).
+ */
+
+export interface FlushGateOptions {
+  /** Maximum messages to buffer before force-flushing */
+  maxBufferSize: number;
+  /** Milliseconds of calm before flushing buffered messages */
+  calmThresholdMs: number;
+  /** Maximum milliseconds to hold messages before force-flushing */
+  maxHoldMs: number;
+}
+
+const DEFAULT_OPTIONS: FlushGateOptions = {
+  maxBufferSize: 100,
+  calmThresholdMs: 50,
+  maxHoldMs: 200,
+};
+
+export class FlushGate {
+  private buffer: string[] = [];
+  private flushCallback: (messages: string[]) => void;
+  private options: FlushGateOptions;
+  private calmTimer: ReturnType<typeof setTimeout> | null = null;
+  private forceTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastMessageTime: number = 0;
+  private _flushedCount: number = 0;
+  private _bufferedCount: number = 0;
+
+  constructor(
+    flushCallback: (messages: string[]) => void,
+    options?: Partial<FlushGateOptions>,
+  ) {
+    this.flushCallback = flushCallback;
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  /**
+   * Enqueue a message. May trigger immediate or deferred flush.
+   */
+  push(message: string): void {
+    this.buffer.push(message);
+    this._bufferedCount++;
+    this.lastMessageTime = Date.now();
+
+    // Force flush if buffer is full
+    if (this.buffer.length >= this.options.maxBufferSize) {
+      this.flush();
+      return;
+    }
+
+    // Reset calm timer
+    if (this.calmTimer) clearTimeout(this.calmTimer);
+    this.calmTimer = setTimeout(() => this.flush(), this.options.calmThresholdMs);
+
+    // Set force timer if not already set
+    if (!this.forceTimer) {
+      this.forceTimer = setTimeout(() => this.flush(), this.options.maxHoldMs);
+    }
+  }
+
+  /**
+   * Flush all buffered messages immediately.
+   */
+  flush(): void {
+    if (this.calmTimer) {
+      clearTimeout(this.calmTimer);
+      this.calmTimer = null;
+    }
+    if (this.forceTimer) {
+      clearTimeout(this.forceTimer);
+      this.forceTimer = null;
+    }
+
+    if (this.buffer.length > 0) {
+      const messages = [...this.buffer];
+      this.buffer = [];
+      this._flushedCount += messages.length;
+      this.flushCallback(messages);
+    }
+  }
+
+  /**
+   * Get stats about the flush gate.
+   */
+  get stats(): { buffered: number; flushed: number; pending: number } {
+    return {
+      buffered: this._bufferedCount,
+      flushed: this._flushedCount,
+      pending: this.buffer.length,
+    };
+  }
+
+  /**
+   * Destroy the gate, flushing remaining messages.
+   */
+  destroy(): void {
+    this.flush();
+  }
+}

--- a/server/src/services/magic-docs.ts
+++ b/server/src/services/magic-docs.ts
@@ -1,0 +1,187 @@
+/**
+ * magic-docs.ts — Auto-suggest prompts from file context + tool registry.
+ *
+ * Analyzes the current file context to suggest relevant prompts,
+ * tools, and commands the user might want to use.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+
+export interface PromptSuggestion {
+  text: string;
+  description: string;
+  source: 'file_context' | 'tool_registry' | 'recent_history' | 'pattern';
+  confidence: number; // 0.0 to 1.0
+  category: string;
+}
+
+interface ToolEntry {
+  name: string;
+  type: string;
+  source: string;
+  description: string;
+}
+
+// File extension → relevant prompt categories
+const EXTENSION_HINTS: Record<string, string[]> = {
+  '.py': ['test', 'lint', 'type-check', 'debug', 'refactor'],
+  '.ts': ['compile', 'test', 'lint', 'type-check', 'build'],
+  '.tsx': ['component', 'test', 'style', 'accessibility'],
+  '.rs': ['build', 'test', 'clippy', 'benchmark'],
+  '.json': ['validate', 'format', 'schema'],
+  '.md': ['proofread', 'format', 'toc'],
+  '.sh': ['shellcheck', 'test', 'permissions'],
+};
+
+// Common prompt templates per category
+const PROMPT_TEMPLATES: Record<string, PromptSuggestion[]> = {
+  test: [
+    { text: 'Write tests for this file', description: 'Generate unit tests', source: 'pattern', confidence: 0.8, category: 'testing' },
+    { text: 'Run existing tests', description: 'Execute test suite', source: 'pattern', confidence: 0.7, category: 'testing' },
+  ],
+  debug: [
+    { text: 'Debug this error', description: 'Analyze and fix errors', source: 'pattern', confidence: 0.7, category: 'debugging' },
+    { text: 'Add logging to trace execution', description: 'Instrument with logging', source: 'pattern', confidence: 0.5, category: 'debugging' },
+  ],
+  refactor: [
+    { text: 'Refactor for readability', description: 'Improve code clarity', source: 'pattern', confidence: 0.6, category: 'refactoring' },
+    { text: 'Extract function', description: 'Pull out reusable logic', source: 'pattern', confidence: 0.5, category: 'refactoring' },
+  ],
+  build: [
+    { text: 'Build and check for errors', description: 'Compile the project', source: 'pattern', confidence: 0.8, category: 'build' },
+  ],
+  lint: [
+    { text: 'Lint and fix issues', description: 'Run linter with auto-fix', source: 'pattern', confidence: 0.7, category: 'quality' },
+  ],
+  component: [
+    { text: 'Add props interface', description: 'Define TypeScript props', source: 'pattern', confidence: 0.6, category: 'react' },
+    { text: 'Add error boundary', description: 'Wrap in error handling', source: 'pattern', confidence: 0.4, category: 'react' },
+  ],
+};
+
+let toolRegistryCache: ToolEntry[] | null = null;
+
+function loadToolRegistry(): ToolEntry[] {
+  if (toolRegistryCache) return toolRegistryCache;
+
+  const registryPath = '/home/hemang/ALETHEIA-NEXUS/config/tool_registry.json';
+  try {
+    if (existsSync(registryPath)) {
+      const data = JSON.parse(readFileSync(registryPath, 'utf-8'));
+      toolRegistryCache = data.tools || [];
+      return toolRegistryCache!;
+    }
+  } catch {
+    // Silently fail — registry is optional
+  }
+  return [];
+}
+
+/**
+ * Get prompt suggestions based on file context.
+ */
+export function getSuggestions(options: {
+  filePath?: string;
+  fileContent?: string;
+  recentPrompts?: string[];
+  maxSuggestions?: number;
+}): PromptSuggestion[] {
+  const suggestions: PromptSuggestion[] = [];
+  const max = options.maxSuggestions || 5;
+
+  // File extension hints
+  if (options.filePath) {
+    const ext = '.' + options.filePath.split('.').pop();
+    const categories = EXTENSION_HINTS[ext] || [];
+    for (const cat of categories) {
+      const templates = PROMPT_TEMPLATES[cat] || [];
+      suggestions.push(...templates);
+    }
+  }
+
+  // Content-based hints
+  if (options.fileContent) {
+    const content = options.fileContent.toLowerCase();
+    if (content.includes('todo') || content.includes('fixme')) {
+      suggestions.push({
+        text: 'Fix all TODOs in this file',
+        description: 'Address TODO/FIXME comments',
+        source: 'file_context',
+        confidence: 0.9,
+        category: 'maintenance',
+      });
+    }
+    if (content.includes('error') || content.includes('exception')) {
+      suggestions.push({
+        text: 'Improve error handling',
+        description: 'Add proper error handling',
+        source: 'file_context',
+        confidence: 0.7,
+        category: 'reliability',
+      });
+    }
+    if (content.includes('import') && content.length > 5000) {
+      suggestions.push({
+        text: 'Split this file into smaller modules',
+        description: 'File is large — consider decomposition',
+        source: 'file_context',
+        confidence: 0.6,
+        category: 'refactoring',
+      });
+    }
+  }
+
+  // Tool registry suggestions
+  const tools = loadToolRegistry();
+  if (options.fileContent && tools.length > 0) {
+    const contentWords = new Set(options.fileContent.toLowerCase().split(/\s+/));
+    for (const tool of tools.slice(0, 50)) {
+      const nameWords = tool.name.toLowerCase().replace(/[_-]/g, ' ').split(' ');
+      const overlap = nameWords.filter(w => contentWords.has(w)).length;
+      if (overlap > 0) {
+        suggestions.push({
+          text: `Use ${tool.name}`,
+          description: tool.description,
+          source: 'tool_registry',
+          confidence: Math.min(overlap * 0.3, 0.9),
+          category: tool.type,
+        });
+      }
+    }
+  }
+
+  // Sort by confidence and deduplicate
+  suggestions.sort((a, b) => b.confidence - a.confidence);
+  const seen = new Set<string>();
+  return suggestions.filter(s => {
+    if (seen.has(s.text)) return false;
+    seen.add(s.text);
+    return true;
+  }).slice(0, max);
+}
+
+/**
+ * Get quick action suggestions for the current context.
+ */
+export function getQuickActions(filePath: string): string[] {
+  const ext = '.' + filePath.split('.').pop();
+  const actions: string[] = [];
+
+  switch (ext) {
+    case '.py':
+      actions.push('pytest', 'mypy', 'black', 'ruff');
+      break;
+    case '.ts':
+    case '.tsx':
+      actions.push('tsc --noEmit', 'npm test', 'eslint');
+      break;
+    case '.rs':
+      actions.push('cargo test', 'cargo clippy', 'cargo build');
+      break;
+    case '.json':
+      actions.push('validate JSON', 'format');
+      break;
+  }
+
+  return actions;
+}

--- a/server/src/services/magic-docs.ts
+++ b/server/src/services/magic-docs.ts
@@ -6,6 +6,8 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
 
 export interface PromptSuggestion {
   text: string;
@@ -64,7 +66,8 @@ let toolRegistryCache: ToolEntry[] | null = null;
 function loadToolRegistry(): ToolEntry[] {
   if (toolRegistryCache) return toolRegistryCache;
 
-  const registryPath = '/home/hemang/ALETHEIA-NEXUS/config/tool_registry.json';
+  const nexusRoot = process.env.ALETHEIA_NEXUS_PATH || join(homedir(), 'ALETHEIA-NEXUS');
+  const registryPath = join(nexusRoot, 'config', 'tool_registry.json');
   try {
     if (existsSync(registryPath)) {
       const data = JSON.parse(readFileSync(registryPath, 'utf-8'));

--- a/server/src/services/session-manager.ts
+++ b/server/src/services/session-manager.ts
@@ -2263,6 +2263,43 @@ export async function spawnAdopt(sessionId: string, socketPath: string, projectP
   pushSystemEvent(`[OctoAlly] Adopted external session ${sessionId}: ${task.slice(0, 60)}`);
 }
 
+/**
+ * Persist session state to database for later resume.
+ */
+export function persistSessionState(sessionId: string): boolean {
+  if (!activeSessions.has(sessionId)) return false;
+
+  const db = getDb();
+  const row = db.prepare('SELECT * FROM sessions WHERE id = ?').get(sessionId) as Session | undefined;
+  if (!row) return false;
+
+  const state = JSON.stringify({
+    id: row.id,
+    task: row.task,
+    project_id: row.project_id,
+    claude_session_id: row.claude_session_id,
+    status: row.status,
+    savedAt: new Date().toISOString(),
+  });
+
+  db.prepare('UPDATE sessions SET session_state = ? WHERE id = ?').run(state, sessionId);
+  return true;
+}
+
+/**
+ * Get persisted session state from database.
+ */
+export function getPersistedState(sessionId: string): Record<string, unknown> | null {
+  const db = getDb();
+  const row = db.prepare('SELECT session_state FROM sessions WHERE id = ?').get(sessionId) as { session_state: string | null } | undefined;
+  if (!row?.session_state) return null;
+  try {
+    return JSON.parse(row.session_state);
+  } catch {
+    return null;
+  }
+}
+
 function killOrphanedProcess(pid: number, sessionId: string): void {
   try {
     process.kill(pid, 0);
@@ -2272,4 +2309,189 @@ function killOrphanedProcess(pid: number, sessionId: string): void {
 
   console.log(`  Killing orphaned process PID ${pid} (session ${sessionId})`);
   killPidTree(pid);
+}
+
+// ─── Capacity Wake ──────────────────────────────────────────
+// Poll-based capacity detection. When a session hits a 429 rate limit,
+// register a wake listener that polls backend health until capacity returns.
+
+interface WakeListener {
+  sessionId: string;
+  registeredAt: number;
+  callback: () => void;
+}
+
+const wakeListeners: WakeListener[] = [];
+let wakePollerActive = false;
+const WAKE_POLL_INTERVAL = 30_000; // 30 seconds
+const WAKE_MAX_AGE = 600_000; // 10 minutes max wait
+
+export function registerCapacityWake(sessionId: string, callback: () => void): void {
+  wakeListeners.push({
+    sessionId,
+    registeredAt: Date.now(),
+    callback,
+  });
+
+  if (!wakePollerActive) {
+    startWakePoller();
+  }
+}
+
+export function removeCapacityWake(sessionId: string): void {
+  const idx = wakeListeners.findIndex(w => w.sessionId === sessionId);
+  if (idx !== -1) wakeListeners.splice(idx, 1);
+  if (wakeListeners.length === 0) {
+    wakePollerActive = false;
+  }
+}
+
+function startWakePoller(): void {
+  wakePollerActive = true;
+
+  const poll = () => {
+    if (!wakePollerActive || wakeListeners.length === 0) {
+      wakePollerActive = false;
+      return;
+    }
+
+    const now = Date.now();
+
+    // Remove expired listeners
+    for (let i = wakeListeners.length - 1; i >= 0; i--) {
+      if (now - wakeListeners[i].registeredAt > WAKE_MAX_AGE) {
+        wakeListeners.splice(i, 1);
+      }
+    }
+
+    if (wakeListeners.length === 0) {
+      wakePollerActive = false;
+      return;
+    }
+
+    // Check capacity by trying a lightweight health check
+    try {
+      const result = execFileSync('python3', ['-m', 'src.backend_health'], {
+        timeout: 5000,
+        encoding: 'utf-8',
+        cwd: '/home/hemang/ALETHEIA-NEXUS',
+      });
+
+      // If health check succeeds and reports usable, wake all listeners
+      if (result.includes('"status": "usable"') || result.includes('"usable"')) {
+        const listenersToWake = [...wakeListeners];
+        wakeListeners.length = 0;
+        wakePollerActive = false;
+
+        for (const listener of listenersToWake) {
+          try {
+            listener.callback();
+          } catch {
+            // Don't let one bad callback kill the rest
+          }
+        }
+        return;
+      }
+    } catch {
+      // Health check failed — keep polling
+    }
+
+    setTimeout(poll, WAKE_POLL_INTERVAL);
+  };
+
+  setTimeout(poll, WAKE_POLL_INTERVAL);
+}
+
+// ─── Coordinator Permission Propagation ──────────────────────
+// When a parent session spawns child sessions (sub-agents),
+// permissions flow from parent to child with optional restrictions.
+
+export interface PermissionGrant {
+  sessionId: string;
+  parentId: string | null;
+  allowedTools: string[];
+  deniedTools: string[];
+  grantedAt: string;
+}
+
+const sessionPermissions: Map<string, PermissionGrant> = new Map();
+
+/**
+ * Grant permissions to a session, optionally inheriting from parent.
+ * If parentId is provided and has a grant, the child inherits the parent's
+ * allowed/denied tools. restrictTools narrows the allowed set (intersection),
+ * denyTools expands the denied set (union).
+ */
+export function grantPermissions(
+  sessionId: string,
+  parentId: string | null,
+  options?: { restrictTools?: string[]; denyTools?: string[] }
+): PermissionGrant {
+  let allowedTools: string[] = [];
+  let deniedTools: string[] = options?.denyTools || [];
+
+  if (parentId) {
+    const parentGrant = sessionPermissions.get(parentId);
+    if (parentGrant) {
+      // Inherit parent's allowed tools
+      allowedTools = [...parentGrant.allowedTools];
+      // Merge parent's denied tools (deny is additive)
+      deniedTools = [...new Set([...parentGrant.deniedTools, ...deniedTools])];
+    }
+  }
+
+  // Apply restrictions (intersection with parent's tools)
+  if (options?.restrictTools && options.restrictTools.length > 0) {
+    if (allowedTools.length > 0) {
+      allowedTools = allowedTools.filter(t => options.restrictTools!.includes(t));
+    } else {
+      allowedTools = [...options.restrictTools];
+    }
+  }
+
+  const grant: PermissionGrant = {
+    sessionId,
+    parentId,
+    allowedTools,
+    deniedTools,
+    grantedAt: new Date().toISOString(),
+  };
+
+  sessionPermissions.set(sessionId, grant);
+  return grant;
+}
+
+/**
+ * Check if a session has permission to use a tool.
+ * Returns true if allowed, false if denied.
+ * Sessions without a grant (root sessions) have no restrictions.
+ */
+export function checkPermission(sessionId: string, toolName: string): boolean {
+  const grant = sessionPermissions.get(sessionId);
+  if (!grant) return true; // No grant = no restrictions (root session)
+
+  // Check denied first (deny always wins over allow)
+  if (grant.deniedTools.some(d => toolName.startsWith(d) || d === toolName)) {
+    return false;
+  }
+
+  // If allowed list is empty, everything not denied is allowed
+  if (grant.allowedTools.length === 0) return true;
+
+  // Check allowed list
+  return grant.allowedTools.some(a => toolName.startsWith(a) || a === toolName);
+}
+
+/**
+ * Get permission grant for a session.
+ */
+export function getPermissions(sessionId: string): PermissionGrant | null {
+  return sessionPermissions.get(sessionId) || null;
+}
+
+/**
+ * Remove permissions when session ends.
+ */
+export function revokePermissions(sessionId: string): boolean {
+  return sessionPermissions.delete(sessionId);
 }

--- a/server/src/services/session-manager.ts
+++ b/server/src/services/session-manager.ts
@@ -12,6 +12,7 @@ import { getSetting } from '../routes/settings.js';
 import { nanoid } from 'nanoid';
 import type { WebSocket } from 'ws';
 import { getOrCreateTracker, removeTracker, recoverFromBuffer } from './session-state.js';
+import { fireNotificationHook } from '../routes/hooks.js';
 
 const nodeRequire = createRequire(import.meta.url);
 const { Terminal: HeadlessTerminal } = nodeRequire('@xterm/headless') as { Terminal: any };
@@ -735,6 +736,28 @@ function wireWorker(sessionId: string, worker: ChildProcess, projectPath?: strin
           type: 'session_end',
           data: { exitCode: msg.exitCode, signal: msg.signal },
         });
+
+        // Fire session_complete notification hook (fire-and-forget)
+        try {
+          fireNotificationHook({
+            type: 'session_complete',
+            session_id: sessionId,
+            detail: { status, exitCode: msg.exitCode, signal: msg.signal ?? null },
+            timestamp: new Date().toISOString(),
+          }).catch(() => { /* non-fatal */ });
+        } catch { /* non-fatal */ }
+
+        // Fire error_spike if the session failed (non-zero exit)
+        if (msg.exitCode !== 0) {
+          try {
+            fireNotificationHook({
+              type: 'error_spike',
+              session_id: sessionId,
+              detail: { exitCode: msg.exitCode, signal: msg.signal ?? null, reason: 'session_failed' },
+              timestamp: new Date().toISOString(),
+            }).catch(() => { /* non-fatal */ });
+          } catch { /* non-fatal */ }
+        }
 
         const taskSnippet = (() => {
           try { return (getDb().prepare('SELECT task FROM sessions WHERE id = ?').get(sessionId) as any)?.task?.slice(0, 60) ?? ''; } catch { return ''; }
@@ -1466,6 +1489,19 @@ export async function killSession(sessionId: string): Promise<boolean> {
   `).run(sessionId);
 
   console.log(`[KILL] Session ${sessionId} killed (db_updated=${result.changes > 0})`);
+
+  // Fire session_complete notification hook for cancelled sessions (fire-and-forget)
+  if (!!active || result.changes > 0) {
+    try {
+      fireNotificationHook({
+        type: 'session_complete',
+        session_id: sessionId,
+        detail: { status: 'cancelled', exitCode: -1, reason: 'killed' },
+        timestamp: new Date().toISOString(),
+      }).catch(() => { /* non-fatal */ });
+    } catch { /* non-fatal */ }
+  }
+
   return !!active || result.changes > 0;
 }
 
@@ -2333,6 +2369,16 @@ export function registerCapacityWake(sessionId: string, callback: () => void): v
     callback,
   });
 
+  // Fire rate_limit notification hook (fire-and-forget)
+  try {
+    fireNotificationHook({
+      type: 'rate_limit',
+      session_id: sessionId,
+      detail: { reason: 'capacity_exhausted', pollingIntervalMs: WAKE_POLL_INTERVAL },
+      timestamp: new Date().toISOString(),
+    }).catch(() => { /* non-fatal */ });
+  } catch { /* non-fatal */ }
+
   if (!wakePollerActive) {
     startWakePoller();
   }
@@ -2472,14 +2518,33 @@ export function checkPermission(sessionId: string, toolName: string): boolean {
 
   // Check denied first (deny always wins over allow)
   if (grant.deniedTools.some(d => toolName.startsWith(d) || d === toolName)) {
+    try {
+      fireNotificationHook({
+        type: 'tool_denied',
+        session_id: sessionId,
+        detail: { tool: toolName, reason: 'explicitly_denied', parentId: grant.parentId },
+        timestamp: new Date().toISOString(),
+      }).catch(() => { /* non-fatal */ });
+    } catch { /* non-fatal */ }
     return false;
   }
 
   // If allowed list is empty, everything not denied is allowed
   if (grant.allowedTools.length === 0) return true;
 
-  // Check allowed list
-  return grant.allowedTools.some(a => toolName.startsWith(a) || a === toolName);
+  // Check allowed list — if not in the allowed list, deny
+  const allowed = grant.allowedTools.some(a => toolName.startsWith(a) || a === toolName);
+  if (!allowed) {
+    try {
+      fireNotificationHook({
+        type: 'tool_denied',
+        session_id: sessionId,
+        detail: { tool: toolName, reason: 'not_in_allowlist', parentId: grant.parentId },
+        timestamp: new Date().toISOString(),
+      }).catch(() => { /* non-fatal */ });
+    } catch { /* non-fatal */ }
+  }
+  return allowed;
 }
 
 /**

--- a/server/src/services/session-manager.ts
+++ b/server/src/services/session-manager.ts
@@ -2420,7 +2420,7 @@ function startWakePoller(): void {
       const result = execFileSync('python3', ['-m', 'src.backend_health'], {
         timeout: 5000,
         encoding: 'utf-8',
-        cwd: '/home/hemang/ALETHEIA-NEXUS',
+        cwd: process.env.ALETHEIA_NEXUS_PATH || join(homedir(), 'ALETHEIA-NEXUS'),
       });
 
       // If health check succeeds and reports usable, wake all listeners


### PR DESCRIPTION
## Summary

This PR adds several features to make OctoAlly more extensible and environment-aware:

### Skills System (new)
- **Skills browser panel** — discovers and lists .md skill files from ~/.claude/commands/ (global) and <project>/.claude/commands/ (project-scoped)
- **Intent-based suggestions** — SkillSuggestBar at bottom of terminal suggests relevant skills as the user types, using fuzzy matching against an intent map
- **Command palette** — Ctrl+K quick-launch for skills and commands
- **Model badges** — visual indicator showing which AI model is active per session

### GPU/CPU Status Indicator (new)
- **Backend:** TCP port probe on /system/status endpoint detects GPU tunnel (port 11435) vs local CPU Ollama (port 11434) with 400ms timeout
- **Frontend:** useGpuStatus() hook polls every 30s, renders a color-coded pill badge (green GPU / yellow CPU / dim OFF) on the skill suggestion bar
- Enables users with remote GPU setups to see connection status at a glance

### Theme & UX Customizations
- **Dark/light theme toggle** with persistent preference
- **Keybindings panel** for shortcut discovery
- **Session replay** component for reviewing past sessions
- **Clipboard bridge** for cross-platform paste support (Windows to Linux via web)

### Server Enhancements
- **Flush-gate service** — controlled output flushing for terminal streams
- **Magic-docs service and routes** — dynamic documentation serving
- **Permissions routes** — endpoint for querying user permissions
- **ALETHEIA_NEXUS_PATH env var** — replaces hardcoded paths, making the server portable across installations

## Test plan
- [ ] Verify /api/skills?project_path=<path> returns project + global skills
- [ ] Type in terminal and confirm skill suggestions appear in the bar
- [ ] Verify /api/system/status returns correct gpu: true/false based on Ollama ports
- [ ] Toggle theme and confirm persistence across page reloads
- [ ] Ctrl+K opens command palette with skill list
- [ ] Verify no regressions in terminal, session management, or project switching