### PR TITLE
Fix App Font Size setting having no visual effect

### DIFF
--- a/dashboard/src/components/SettingsModal.tsx
+++ b/dashboard/src/components/SettingsModal.tsx
@@ -62,7 +62,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   const [agentClaudeCmd, setAgentClaudeCmd] = useState('');
   const [agentCodexCmd, setAgentCodexCmd] = useState('');
   const [fontSize, setFontSize] = useState('13');
-  const [appFontSize, setAppFontSize] = useState('13');
+  const [appFontSize, setAppFontSize] = useState('16');
   const [serverPort, setServerPort] = useState('42010');
   const [saved, setSaved] = useState(false);
 
@@ -74,7 +74,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
       setAgentClaudeCmd(s.agent_claude_command || '');
       setAgentCodexCmd(s.agent_codex_command || '');
       setFontSize(s.terminal_font_size || '13');
-      setAppFontSize(s.app_font_size || '13');
+      setAppFontSize(s.app_font_size || '16');
       setServerPort(s.server_port || '42010');
     }
   }, [data]);
@@ -298,7 +298,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                       <input
                         type="range"
                         min="10"
-                        max="20"
+                        max="32"
                         step="1"
                         value={appFontSize}
                         onChange={(e) => {
@@ -310,7 +310,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                       />
                       <div className="flex justify-between text-xs" style={{ color: 'var(--text-secondary)', opacity: 0.5 }}>
                         <span>10</span>
-                        <span>20</span>
+                        <span>32</span>
                       </div>
                     </div>
 

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -14,12 +14,15 @@
   --error: #ef4444;
 }
 
+html {
+  font-size: var(--app-font-size, 16px);
+}
+
 body {
   margin: 0;
   background: var(--bg-primary);
   color: var(--text-primary);
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-size: var(--app-font-size, 13px);
 }
 
 /* Global interactive element styles */

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -14,7 +14,7 @@ const DEFAULTS: Record<string, string> = {
   agent_claude_command: 'claude',
   agent_codex_command: 'codex',
   terminal_font_size: '13',
-  app_font_size: '13',
+  app_font_size: '16',
   server_port: '42010',
   ruflo_disposition: 'undecided',   // undecided | keep | remove_all | removed
   statusline_prompted: 'false',    // whether we've asked the user about statusline install


### PR DESCRIPTION
The --app-font-size CSS variable was applied to `body`, but the entire UI uses Tailwind v4 text-* classes which are expressed in `rem` units. Since `rem` is relative to the root element (`html`), not `body`, the variable had no effect on any Tailwind-styled text — moving the slider in Settings did nothing visible.

Fix:
- Apply `font-size: var(--app-font-size)` to `html` instead of `body`, so rem-based classes scale with the user-configured value.
- Bump the default from 13 to 16 (browser/Tailwind baseline) so the default visual size matches what was previously rendered. Defaults updated in index.css fallback, SettingsModal initial state, and the backend `app_font_size` default.
- Raise the slider max from 20 to 32 for users who want significantly larger text.