### PR TITLE
fix(launcher): scrub stale NODE_OPTIONS before spawning server

### DIFF
--- a/bin/octoally
+++ b/bin/octoally
@@ -190,7 +190,12 @@ cmd_start() {
     fi
   fi
 
-  env NODE_ENV=production node dist/index.js >> "$OCTOALLY_DIR/logs/octoally.log" 2>&1 &
+  # Scrub NODE_OPTIONS: if octoally was launched from a shell with a
+  # context-mode/claude-mem preload active, NODE_OPTIONS carries a per-PID
+  # --require shim in /tmp that dies with that shell. Inheriting it makes the
+  # server hand a dead module path to every spawned session, crashing them
+  # with "Cannot find module /tmp/cm-fs-preload-*.js". -u keeps it out.
+  env -u NODE_OPTIONS NODE_ENV=production node dist/index.js >> "$OCTOALLY_DIR/logs/octoally.log" 2>&1 &
   local pid=$!
   echo "$pid" > "$PID_FILE"
   log_ok "OctoAlly started (PID $pid)"
@@ -487,7 +492,8 @@ cmd_logs() {
   else
     log_info "Starting server in foreground (Ctrl+C to stop)..."
     cd "$OCTOALLY_DIR/server"
-    env NODE_ENV=production node dist/index.js
+    # See cmd_start: scrub a stale context-mode/claude-mem NODE_OPTIONS preload.
+    env -u NODE_OPTIONS NODE_ENV=production node dist/index.js
   fi
 }
 


### PR DESCRIPTION
## Problem

When `octoally` is launched from a shell that has a **context-mode / claude-mem** preload active, the environment carries:

```
NODE_OPTIONS=--require /tmp/cm-fs-preload-<pid>.js
```

That preload is a per-PID temp shim that dies with the launching shell. The long-running server keeps the env var and passes it to **every `claude` child it spawns**, so each new session crashes immediately at startup:

```
Error: Cannot find module '/tmp/cm-fs-preload-<pid>.js'
[KILL] Session <id> kill timed out after 3s, forcing DB update
```

OctoAlly then reports the session as failed/cancelled (`pid: null`, `started_at: null`). Symptom: **every new session started from a project fails instantly**, while the server itself stays up and healthy.

Observed in the wild on a server that had been running ~13 days after being started from a context-mode-enabled shell.

## Fix

Add `env -u NODE_OPTIONS` to both server-launch paths:
- `cmd_start` (daemon / direct-run mode)
- the `cmd_logs` foreground fallback

so the server can never inherit a stale preload, regardless of the shell it's launched from.

`systemd`/`launchd` installs already start from a minimal environment and were never affected — only direct-run mode inherits the calling shell's env.

## Verification

- `bash -n bin/octoally` — passes
- With a deliberately poisoned `NODE_OPTIONS=--require /tmp/cm-fs-preload-DEADBEEF.js`, a child spawned via `env -u NODE_OPTIONS … node` sees `NODE_OPTIONS = null` and starts cleanly.
- After applying the guard and restarting, new sessions spawn without the `Cannot find module` error.