### PR TITLE
feat(projects): editable working directory + path normalization

### DIFF
--- a/dashboard/src/components/ProjectDashboard.tsx
+++ b/dashboard/src/components/ProjectDashboard.tsx
@@ -118,6 +118,14 @@ function prevFolderName(path: string): string {
   return parts[parts.length - 1] || '';
 }
 
+/** Strip trailing slashes / whitespace so a typed `/home/x/repos/` compares and saves
+ *  the same as the picker's `/home/x/repos`. Mirrors the server's normalizeProjectPath. */
+function normalizePath(path: string): string {
+  const trimmed = (path || '').trim();
+  if (trimmed === '/' || trimmed === '') return trimmed;
+  return trimmed.replace(/\/+$/, '');
+}
+
 const inputStyle = {
   background: 'var(--bg-tertiary)',
   borderColor: 'var(--border)',
@@ -238,6 +246,7 @@ function ProjectForm({
     mutationFn: () => {
       const fields: Record<string, string | number | null | undefined> = {};
       if (name !== project!.name) fields.name = name;
+      if (normalizePath(path) !== normalizePath(project!.path)) fields.path = normalizePath(path);
       if (description !== (project!.description || '')) fields.description = description;
       if (defaultWebUrl !== (project!.default_web_url || '')) fields.default_web_url = defaultWebUrl || null;
       if (sessionPrompt !== (project!.session_prompt || ''))
@@ -249,7 +258,8 @@ function ProjectForm({
       return api.projects.update(project!.id, fields as any);
     },
     onSuccess: async () => {
-      const savePath = project!.path;
+      // Write any edited files to the (possibly repointed) path, not the stale one.
+      const savePath = normalizePath(path) || project!.path;
       try {
         if (claudeMd !== initialClaudeMd) await api.files.write(`${savePath}/CLAUDE.md`, claudeMd);
         if (agentsMd !== initialAgentsMd) await api.files.write(`${savePath}/AGENTS.md`, agentsMd);
@@ -272,7 +282,8 @@ function ProjectForm({
 
   const handleFolderSelect = (selectedPath: string, folderName: string) => {
     setPath(selectedPath);
-    if (!name || name === prevFolderName(path)) setName(folderName);
+    // Don't auto-rename in edit mode, and never clobber a manually-set name.
+    if (mode === 'add' && (!name || name === prevFolderName(path))) setName(folderName);
     setShowBrowser(false);
   };
 
@@ -317,6 +328,30 @@ function ProjectForm({
   const hasGitRepo = gitStatusData !== null && gitStatusData !== undefined;
   const hasRemote = hasGitRepo && !!gitStatusData?.remoteUrl;
 
+  // Warn-only validation for the working directory (add + edit). Never blocks save —
+  // the folder may be created later, so these are advisory, not errors.
+  const editingPath = normalizePath(path);
+  const projectsListQuery = useQuery({ queryKey: ['projects'], queryFn: () => api.projects.list() });
+  const otherProjects = (projectsListQuery.data?.projects || []).filter((p) => p.id !== project?.id);
+
+  const pathExistsQuery = useQuery({
+    queryKey: ['path-exists', editingPath],
+    queryFn: () => api.projects.browse(editingPath).then(() => true).catch(() => false),
+    enabled: !!editingPath,
+    retry: false,
+  });
+
+  const pathChanged = mode === 'edit' && editingPath !== normalizePath(project!.path);
+  const pathWarnings: string[] = [];
+  if (editingPath) {
+    if (!editingPath.startsWith('/')) pathWarnings.push('Path is not absolute — it should start with "/".');
+    if (pathExistsQuery.data === false) pathWarnings.push("This folder doesn't exist on disk yet.");
+    if (otherProjects.some((p) => normalizePath(p.path) === editingPath))
+      pathWarnings.push('Another project already points at this exact folder.');
+    else if (otherProjects.some((p) => normalizePath(p.path).startsWith(editingPath + '/')))
+      pathWarnings.push("This is a parent of another project's folder — sessions may open in the wrong place.");
+  }
+
   return (
     <div className="h-full overflow-y-auto p-6">
       <div className="mx-auto" style={{ maxWidth: '1100px' }}>
@@ -340,56 +375,62 @@ function ProjectForm({
           style={{ background: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
         >
           <div className="flex flex-col gap-4">
-            {/* Folder Path — add mode only */}
-            {mode === 'add' && (
-              <div>
-                <label className="block text-xs mb-1" style={{ color: 'var(--text-secondary)' }}>Folder Path</label>
-                <div className="flex gap-2">
-                  <input
-                    value={path}
-                    onChange={(e) => {
-                      const val = e.target.value;
-                      const folderName = prevFolderName(val);
-                      setPath(val);
-                      if (!name || name === prevFolderName(path)) setName(folderName);
-                    }}
-                    placeholder="/home/user/projects/myapp"
-                    className="flex-1 px-4 py-2.5 rounded-lg border text-sm outline-none font-mono"
-                    style={inputStyle}
-                  />
-                  <button
-                    onClick={() => setShowBrowser(!showBrowser)}
-                    className="px-3 py-2.5 rounded-lg border text-sm flex items-center gap-1.5"
-                    style={{
-                      background: showBrowser ? 'var(--accent)' : 'var(--bg-tertiary)',
-                      borderColor: 'var(--border)',
-                      color: showBrowser ? 'white' : 'var(--text-secondary)',
-                    }}
-                  >
-                    <FolderOpen className="w-4 h-4" />
-                    Browse
-                  </button>
-                </div>
+            {/* Folder Path — editable in both add and edit mode.
+                In edit mode this repoints the project (DB only); files are NOT moved. */}
+            <div>
+              <label className="block text-xs mb-1" style={{ color: 'var(--text-secondary)' }}>
+                {mode === 'add' ? 'Folder Path' : 'Working Directory'}
+              </label>
+              <div className="flex gap-2">
+                <input
+                  value={path}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    const folderName = prevFolderName(val);
+                    setPath(val);
+                    // Only auto-fill the name from the folder while it still tracks the path
+                    // (don't clobber a manually-set name, and never in edit mode).
+                    if (mode === 'add' && (!name || name === prevFolderName(path))) setName(folderName);
+                  }}
+                  placeholder="/home/user/projects/myapp"
+                  className="flex-1 px-4 py-2.5 rounded-lg border text-sm outline-none font-mono"
+                  style={inputStyle}
+                />
+                <button
+                  onClick={() => setShowBrowser(!showBrowser)}
+                  className="px-3 py-2.5 rounded-lg border text-sm flex items-center gap-1.5"
+                  style={{
+                    background: showBrowser ? 'var(--accent)' : 'var(--bg-tertiary)',
+                    borderColor: 'var(--border)',
+                    color: showBrowser ? 'white' : 'var(--text-secondary)',
+                  }}
+                >
+                  <FolderOpen className="w-4 h-4" />
+                  Browse
+                </button>
               </div>
-            )}
+              {mode === 'edit' && pathChanged && (
+                <p className="text-[10px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                  Repoints this project to a new folder. Files are not moved or renamed.
+                </p>
+              )}
+              {/* Warn-only validation — advisory, does not block saving */}
+              {pathWarnings.length > 0 && (
+                <div className="mt-1.5 flex flex-col gap-0.5">
+                  {pathWarnings.map((w) => (
+                    <p key={w} className="text-[10px] flex items-start gap-1" style={{ color: '#f59e0b' }}>
+                      <AlertTriangle className="w-3 h-3 mt-px shrink-0" />
+                      <span>{w}</span>
+                    </p>
+                  ))}
+                </div>
+              )}
+            </div>
 
             {/* Folder Browser */}
-            {mode === 'add' && showBrowser && (
+            {showBrowser && (
               <div>
                 <FolderBrowser onSelect={handleFolderSelect} />
-              </div>
-            )}
-
-            {/* Edit mode: show path as read-only */}
-            {mode === 'edit' && (
-              <div>
-                <label className="block text-xs mb-1" style={{ color: 'var(--text-secondary)' }}>Path</label>
-                <div
-                  className="px-4 py-2.5 rounded-lg border text-sm font-mono"
-                  style={{ background: 'var(--bg-primary)', borderColor: 'var(--border)', color: 'var(--text-secondary)' }}
-                >
-                  {project!.path}
-                </div>
               </div>
             )}
 
@@ -875,7 +916,7 @@ function ProjectForm({
             <div className="flex items-center gap-3 pt-2">
               <button
                 onClick={handleSave}
-                disabled={isPending || !name || (mode === 'add' && !path)}
+                disabled={isPending || !name || !path.trim()}
                 className="flex items-center gap-2 px-6 py-2.5 rounded-lg text-sm font-medium disabled:opacity-50"
                 style={{ background: 'var(--accent)', color: 'white' }}
               >

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -83,7 +83,7 @@ export const api = {
         method: 'POST',
         body: JSON.stringify(data),
       }),
-    update: (id: string, data: { name?: string; description?: string; session_prompt?: string | null; openclaw_prompt?: string | null; default_web_url?: string | null; skip_permissions?: number; color?: string }) =>
+    update: (id: string, data: { name?: string; path?: string; description?: string; session_prompt?: string | null; openclaw_prompt?: string | null; default_web_url?: string | null; skip_permissions?: number; color?: string }) =>
       fetchJSON<{ ok: boolean; project: Project }>(`/projects/${id}`, {
         method: 'PATCH',
         body: JSON.stringify(data),

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -243,6 +243,19 @@ export interface Project {
   updated_at: string;
 }
 
+/**
+ * Normalize a project path before it touches the DB.
+ * Strips trailing slashes (the #1 cause of `/home/marty/repos/`-style entries,
+ * which the folder picker never produces but free-text typing does) and trims
+ * whitespace. Keeps the value otherwise verbatim — we do NOT reject here, since
+ * validation is warn-only by design (the folder may be created later).
+ */
+function normalizeProjectPath(p: string): string {
+  const trimmed = (p || '').trim();
+  if (trimmed === '/' || trimmed === '') return trimmed;
+  return trimmed.replace(/\/+$/, '');
+}
+
 /** ~/.octoally/projects.json — portable backup, not the source of truth */
 const OCTOALLY_DIR = join(homedir(), '.octoally');
 const PROJECTS_FILE = join(OCTOALLY_DIR, 'projects.json');
@@ -311,7 +324,8 @@ export const projectRoutes: FastifyPluginAsync = async (app) => {
   app.post<{
     Body: { name: string; path: string; description?: string; session_prompt?: string; openclaw_prompt?: string; default_web_url?: string; color?: string };
   }>('/projects', async (req, reply) => {
-    const { name, path, description, session_prompt, openclaw_prompt, default_web_url, color } = req.body;
+    const { name, description, session_prompt, openclaw_prompt, default_web_url, color } = req.body;
+    const path = normalizeProjectPath(req.body.path);
     if (!name || !path) return reply.status(400).send({ error: 'name and path are required' });
 
     const db = getDb();
@@ -335,13 +349,26 @@ export const projectRoutes: FastifyPluginAsync = async (app) => {
   // Update project
   app.patch<{
     Params: { id: string };
-    Body: { name?: string; description?: string; session_prompt?: string | null; openclaw_prompt?: string | null; default_web_url?: string | null; skip_permissions?: number; color?: string };
+    Body: { name?: string; path?: string; description?: string; session_prompt?: string | null; openclaw_prompt?: string | null; default_web_url?: string | null; skip_permissions?: number; color?: string };
   }>('/projects/:id', async (req, reply) => {
     const db = getDb();
     const updates: string[] = [];
     const params: unknown[] = [];
 
     if (req.body.name) { updates.push('name = ?'); params.push(req.body.name); }
+    // Repoint the project at a different working directory. Files are NOT moved —
+    // this only updates where OctoAlly looks. Normalized (trailing-slash stripped)
+    // and required non-empty; existence/duplication is surfaced as a warning in the
+    // UI, not enforced here.
+    if (req.body.path !== undefined) {
+      const p = normalizeProjectPath(req.body.path);
+      if (!p) return reply.status(400).send({ error: 'path cannot be empty' });
+      // projects.path is UNIQUE — translate an exact collision into a clean 409
+      // instead of letting the constraint surface as a 500.
+      const clash = db.prepare('SELECT id FROM projects WHERE path = ? AND id <> ?').get(p, req.params.id);
+      if (clash) return reply.status(409).send({ error: 'Another project already uses this path' });
+      updates.push('path = ?'); params.push(p);
+    }
     if (req.body.description !== undefined) { updates.push('description = ?'); params.push(req.body.description); }
     if (req.body.session_prompt !== undefined) { updates.push('session_prompt = ?'); params.push(req.body.session_prompt); }
     if (req.body.openclaw_prompt !== undefined) { updates.push('openclaw_prompt = ?'); params.push(req.body.openclaw_prompt); }


### PR DESCRIPTION
## Problem

Projects could silently end up pointing at a **parent** directory — e.g. a project saved with path `/home/marty/repos/` instead of `/home/marty/repos/local-event-monitor`. Two root causes:

1. **No normalization / validation on save.** `POST /projects` stored `req.body.path` verbatim. A trailing slash, a bare parent dir, or a non-existent path was all accepted silently. (The folder picker never produces a trailing slash — `resolve()`/`join()` strip it — so these entries come from free-text typing.)
2. **No way to fix it afterward.** Edit mode rendered the path **read-only**, and `PATCH /projects/:id` didn't accept a `path` field at all.

## Changes

**Server (`routes/projects.ts`)**
- `normalizeProjectPath()` — trims whitespace and strips trailing slashes. Applied on **create** and on the new PATCH path branch.
- `PATCH /projects/:id` now accepts `path` (**repoint only — files are not moved**). Empty path → `400`. Because `projects.path` is `UNIQUE`, an exact collision is translated into a clean **`409`** instead of surfacing the constraint as a `500`.

**Dashboard (`ProjectDashboard.tsx`, `lib/api.ts`)**
- **Working Directory is editable in edit mode** (text input + folder browser), no longer read-only. Repointing shows a "files are not moved" hint.
- **Warn-only validation** (add + edit): flags non-existent folders, non-absolute paths, and **"this is a parent of another project's folder"** — advisory, never blocks save.
- Update mutation sends the normalized path and writes edited CLAUDE.md/AGENTS.md/settings to the new location; folder-pick no longer auto-renames in edit mode.

## Verification

Built and deployed against the running v1.0.84 instance; tested live:
- PATCH path with trailing slash → stored normalized (no slash) ✓
- PATCH to an exact-duplicate path → `409` with a clear message ✓
- PATCH empty path → `400` ✓
- `tsc --noEmit` + production builds pass for server and dashboard.